### PR TITLE
SDK user info now available immediately on connection

### DIFF
--- a/Example/Tests/TestAccountSession.m
+++ b/Example/Tests/TestAccountSession.m
@@ -199,6 +199,40 @@
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 }
 
+- (void) testUserAuthorizationInfoAvailableImmediately
+{
+    ZingleAccountSession * session = [ZingleSDK accountSessionWithToken:@"token" key:@"key"];
+    
+    // Set the HTTP client to nil to prevent reaching out through the internet tubes if we forget to stub something
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+    session.sessionManager = nil;
+#pragma clang diagnostic pop
+    
+    ZNGMockAccountClient * accountClient = [[ZNGMockAccountClient alloc] initWithSession:session];
+    accountClient.accounts = @[account1];
+    session.accountClient = accountClient;
+    
+    ZNGMockServiceClient * serviceClient = [[ZNGMockServiceClient alloc] initWithSession:session];
+    serviceClient.services = @[account1service1];
+    session.serviceClient = serviceClient;
+    
+    ZNGMockUserAuthorizationClient * userAuthClient = [[ZNGMockUserAuthorizationClient alloc] initWithSession:session];
+    userAuthClient.contact = contact1;
+    userAuthClient.authorizationClass = @"account";
+    session.userAuthorizationClient = userAuthClient;
+    
+    XCTestExpectation * connected = [self expectationWithDescription:@"Connected successfully"];
+    
+    [session connectWithCompletion:^(ZNGService * _Nullable service, ZNGError * _Nullable error) {
+        [connected fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+    
+    XCTAssertNotNil([session.userAuthorization displayName], @"Authenticated user information should be available on login.");
+}
+
 - (void) testRegisteredForPushNotifications
 {
     ZingleAccountSession * session = [ZingleSDK accountSessionWithToken:@"token" key:@"key"];
@@ -285,7 +319,7 @@
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 }
 
-- (void) testRelevantPushNotifcationTriggersServieRefresh
+- (void) testRelevantPushNotifcationTriggersServiceRefresh
 {
     ZingleAccountSession * session = [ZingleSDK accountSessionWithToken:@"token" key:@"key"];
     

--- a/Example/Tests/TestAccountSession.m
+++ b/Example/Tests/TestAccountSession.m
@@ -118,6 +118,11 @@
     serviceClient.services = @[account1service1];
     session.serviceClient = serviceClient;
     
+    ZNGMockUserAuthorizationClient * userAuthClient = [[ZNGMockUserAuthorizationClient alloc] initWithSession:session];
+    userAuthClient.contact = contact1;
+    userAuthClient.authorizationClass = @"account";
+    session.userAuthorizationClient = userAuthClient;
+    
     XCTestExpectation * connected = [self expectationWithDescription:@"Connected successfully"];
     
     [session connectWithAccountChooser:^ZNGAccount * _Nullable(NSArray<ZNGAccount *> * _Nonnull availableAccounts) {
@@ -182,6 +187,11 @@
     ZNGMockServiceClient * serviceClient = [[ZNGMockServiceClient alloc] initWithSession:session];
     serviceClient.services = @[account2service1, account2service2];
     session.serviceClient = serviceClient;
+    
+    ZNGMockUserAuthorizationClient * userAuthClient = [[ZNGMockUserAuthorizationClient alloc] initWithSession:session];
+    userAuthClient.contact = contact1;
+    userAuthClient.authorizationClass = @"account";
+    session.userAuthorizationClient = userAuthClient;
     
     XCTestExpectation * serviceChooserCalled = [self expectationWithDescription:@"Service chooser block called"];
     [self keyValueObservingExpectationForObject:session keyPath:NSStringFromSelector(@selector(service)) expectedValue:account2service1];
@@ -254,6 +264,11 @@
     ZNGMockNotificationsClient * notificationsClient = [[ZNGMockNotificationsClient alloc] initWithSession:session];
     session.notificationsClient = notificationsClient;
     
+    ZNGMockUserAuthorizationClient * userAuthClient = [[ZNGMockUserAuthorizationClient alloc] initWithSession:session];
+    userAuthClient.contact = contact1;
+    userAuthClient.authorizationClass = @"account";
+    session.userAuthorizationClient = userAuthClient;
+    
     [ZingleSDK setPushNotificationDeviceToken:deviceToken];
     
     XCTestExpectation * connected = [self expectationWithDescription:@"Connected successfully"];
@@ -291,6 +306,11 @@
     
     ZNGMockNotificationsClient * notificationsClient = [[ZNGMockNotificationsClient alloc] initWithSession:session];
     session.notificationsClient = notificationsClient;
+    
+    ZNGMockUserAuthorizationClient * userAuthClient = [[ZNGMockUserAuthorizationClient alloc] initWithSession:session];
+    userAuthClient.contact = contact1;
+    userAuthClient.authorizationClass = @"account";
+    session.userAuthorizationClient = userAuthClient;
     
     [ZingleSDK setPushNotificationDeviceToken:deviceToken];
     
@@ -337,6 +357,11 @@
     serviceClient.services = @[account1service1];
     session.serviceClient = serviceClient;
     
+    ZNGMockUserAuthorizationClient * userAuthClient = [[ZNGMockUserAuthorizationClient alloc] initWithSession:session];
+    userAuthClient.contact = contact1;
+    userAuthClient.authorizationClass = @"account";
+    session.userAuthorizationClient = userAuthClient;
+    
     XCTestExpectation * connected = [self expectationWithDescription:@"Connected successfully"];
     
     [session connectWithAccountChooser:nil serviceChooser:nil completion:^(ZNGService * _Nullable service, ZNGError * _Nullable error) {
@@ -374,6 +399,11 @@
     ZNGMockServiceClient * serviceClient = [[ZNGMockServiceClient alloc] initWithSession:session];
     serviceClient.services = @[account1service1];
     session.serviceClient = serviceClient;
+    
+    ZNGMockUserAuthorizationClient * userAuthClient = [[ZNGMockUserAuthorizationClient alloc] initWithSession:session];
+    userAuthClient.contact = contact1;
+    userAuthClient.authorizationClass = @"account";
+    session.userAuthorizationClient = userAuthClient;
     
     XCTestExpectation * connected = [self expectationWithDescription:@"Connected successfully"];
     


### PR DESCRIPTION
Zingle account sessions will no longer be marked as available/connected just before the current user information has been acquired from the API root.  Connection now only happens after the user info has been retrieved.

Added a unit test to ensure this.