### PR TITLE
Added readonly properties to access the attributes of an initials avatar

### DIFF
--- a/Pod/Classes/UI/Avatars/ZNGInitialsAvatar.h
+++ b/Pod/Classes/UI/Avatars/ZNGInitialsAvatar.h
@@ -18,6 +18,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id) initWithInitials:(NSString *)initials textColor:(UIColor *)textColor backgroundColor:(UIColor *)backgroundColor size:(CGSize)size font:(UIFont *)font;
 
+@property (nonatomic, readonly) NSString * initials;
+@property (nonatomic, readonly) UIColor * textColor;
+@property (nonatomic, readonly) UIColor * backgroundColor;
+@property (nonatomic, readonly) CGSize size;
+@property (nonatomic, readonly) UIFont * font;
+
 NS_ASSUME_NONNULL_END
 
 @end

--- a/Pod/Classes/UI/Avatars/ZNGInitialsAvatar.m
+++ b/Pod/Classes/UI/Avatars/ZNGInitialsAvatar.m
@@ -18,6 +18,12 @@
     self = [super init];
     
     if (self != nil) {
+        _initials = initials;
+        _textColor = textColor;
+        _backgroundColor = backgroundColor;
+        _size = size;
+        _font = font;
+        
         CGRect rect = CGRectMake(0.0, 0.0, size.width, size.height);
         UIGraphicsBeginImageContextWithOptions(size, NO, 0.0);
         CGContextRef context = UIGraphicsGetCurrentContext();


### PR DESCRIPTION
Sometimes you need previous avatars to make new avatars, 🐕 