### PR TITLE
IOS-610: User avatar SDK support

### DIFF
--- a/Example/Tests/TestAccountSession.m
+++ b/Example/Tests/TestAccountSession.m
@@ -225,7 +225,7 @@
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 }
 
-- (void) testUserAuthorizationInfoAvailableImmediately
+- (void) testUserAuthorizationAndUserInfoAvailableImmediately
 {
     ZingleAccountSession * session = [ZingleSDK accountSessionWithToken:@"token" key:@"key"];
     
@@ -260,7 +260,8 @@
     
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
     
-    XCTAssertNotNil([session.userAuthorization displayName], @"Authenticated user information should be available on login.");
+    XCTAssertNotNil([session.userAuthorization displayName], @"Authenticated user information (ZNGUserAuthorization) should be available on login.");
+    XCTAssertNotNil(session.user.userId, @"User information (ZNGUser) should be available on login.");
 }
 
 - (void) testRegisteredForPushNotifications

--- a/Example/Tests/TestAccountSession.m
+++ b/Example/Tests/TestAccountSession.m
@@ -14,6 +14,7 @@
 #import "ZNGMockNotificationsClient.h"
 #import "ZNGMockServiceClient.h"
 #import "ZNGMockUserAuthorizationClient.h"
+#import "ZNGMockUserClient.h"
 @import CocoaLumberjack;
 
 @interface TestAccountSession : XCTestCase
@@ -31,6 +32,7 @@
     ZNGAccount * account2;
     
     ZNGContact * contact1;
+    ZNGUser * user1;
 }
 
 - (void)setUp
@@ -98,6 +100,12 @@
     
     contact1.customFieldValues = @[firstName, lastName];
     contact1.contactId = @"00000000-0000-0000-0000-1234abcd1234";
+    
+    
+    user1 = [[ZNGUser alloc] init];
+    user1.firstName = [[contact1 firstNameFieldValue] value];
+    user1.lastName = [[contact1 lastNameFieldValue] value];
+    user1.userId = contact1.contactId;
 }
 
 - (void) testSingleAccountSingleServiceLogin
@@ -122,6 +130,10 @@
     userAuthClient.contact = contact1;
     userAuthClient.authorizationClass = @"account";
     session.userAuthorizationClient = userAuthClient;
+    
+    ZNGMockUserClient * userClient = [[ZNGMockUserClient alloc] initWithSession:session accountId:account1.accountId];
+    userClient.user = user1;
+    session.userClient = userClient;
     
     XCTestExpectation * connected = [self expectationWithDescription:@"Connected successfully"];
     
@@ -193,6 +205,10 @@
     userAuthClient.authorizationClass = @"account";
     session.userAuthorizationClient = userAuthClient;
     
+    ZNGMockUserClient * userClient = [[ZNGMockUserClient alloc] initWithSession:session accountId:account2.accountId];
+    userClient.user = user1;
+    session.userClient = userClient;
+    
     XCTestExpectation * serviceChooserCalled = [self expectationWithDescription:@"Service chooser block called"];
     [self keyValueObservingExpectationForObject:session keyPath:NSStringFromSelector(@selector(service)) expectedValue:account2service1];
     [self keyValueObservingExpectationForObject:session keyPath:NSStringFromSelector(@selector(available)) expectedValue:@YES];
@@ -232,6 +248,10 @@
     userAuthClient.authorizationClass = @"account";
     session.userAuthorizationClient = userAuthClient;
     
+    ZNGMockUserClient * userClient = [[ZNGMockUserClient alloc] initWithSession:session accountId:account1.accountId];
+    userClient.user = user1;
+    session.userClient = userClient;
+    
     XCTestExpectation * connected = [self expectationWithDescription:@"Connected successfully"];
     
     [session connectWithCompletion:^(ZNGService * _Nullable service, ZNGError * _Nullable error) {
@@ -268,6 +288,10 @@
     userAuthClient.contact = contact1;
     userAuthClient.authorizationClass = @"account";
     session.userAuthorizationClient = userAuthClient;
+    
+    ZNGMockUserClient * userClient = [[ZNGMockUserClient alloc] initWithSession:session accountId:account1.accountId];
+    userClient.user = user1;
+    session.userClient = userClient;
     
     [ZingleSDK setPushNotificationDeviceToken:deviceToken];
     
@@ -311,6 +335,10 @@
     userAuthClient.contact = contact1;
     userAuthClient.authorizationClass = @"account";
     session.userAuthorizationClient = userAuthClient;
+    
+    ZNGMockUserClient * userClient = [[ZNGMockUserClient alloc] initWithSession:session accountId:account1.accountId];
+    userClient.user = user1;
+    session.userClient = userClient;
     
     [ZingleSDK setPushNotificationDeviceToken:deviceToken];
     
@@ -362,6 +390,10 @@
     userAuthClient.authorizationClass = @"account";
     session.userAuthorizationClient = userAuthClient;
     
+    ZNGMockUserClient * userClient = [[ZNGMockUserClient alloc] initWithSession:session accountId:account1.accountId];
+    userClient.user = user1;
+    session.userClient = userClient;
+    
     XCTestExpectation * connected = [self expectationWithDescription:@"Connected successfully"];
     
     [session connectWithAccountChooser:nil serviceChooser:nil completion:^(ZNGService * _Nullable service, ZNGError * _Nullable error) {
@@ -404,6 +436,10 @@
     userAuthClient.contact = contact1;
     userAuthClient.authorizationClass = @"account";
     session.userAuthorizationClient = userAuthClient;
+    
+    ZNGMockUserClient * userClient = [[ZNGMockUserClient alloc] initWithSession:session accountId:account1.accountId];
+    userClient.user = user1;
+    session.userClient = userClient;
     
     XCTestExpectation * connected = [self expectationWithDescription:@"Connected successfully"];
     

--- a/Example/Tests/mocks/ZNGMockUserClient.h
+++ b/Example/Tests/mocks/ZNGMockUserClient.h
@@ -1,0 +1,17 @@
+//
+//  ZNGMockUserClient.h
+//  ZingleSDK
+//
+//  Created by Jason Neel on 4/10/17.
+//  Copyright © 2017 Zingle. All rights reserved.
+//
+
+#import "ZingleSDK/ZNGUserClient.h"
+
+@class ZNGContact;
+
+@interface ZNGMockUserClient : ZNGUserClient
+
+@property (nonatomic, strong) ZNGUser * user;
+
+@end

--- a/Example/Tests/mocks/ZNGMockUserClient.m
+++ b/Example/Tests/mocks/ZNGMockUserClient.m
@@ -1,0 +1,28 @@
+//
+//  ZNGMockUserClient.m
+//  ZingleSDK
+//
+//  Created by Jason Neel on 4/10/17.
+//  Copyright © 2017 Zingle. All rights reserved.
+//
+
+#import "ZNGMockUserClient.h"
+
+@implementation ZNGMockUserClient
+
+- (void) userWithId:(NSString *)userId success:(void (^)(ZNGUser *, ZNGStatus *))success failure:(void (^)(ZNGError *))failure
+{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.15 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        ZNGStatus * status = [[ZNGStatus alloc] init];
+        status.pageSize = 50;
+        status.page = 1;
+        status.totalPages = (self.user != nil) ? 1 : 0;
+        status.totalRecords = status.totalPages;
+        
+        if (success != nil) {
+            success(self.user, status);
+        }
+    });
+}
+
+@end

--- a/Example/ZingleSDK.xcodeproj/project.pbxproj
+++ b/Example/ZingleSDK.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		6003F59E195388D20070C39A /* ZNGAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 6003F59D195388D20070C39A /* ZNGAppDelegate.m */; };
 		6003F5A9195388D20070C39A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6003F5A8195388D20070C39A /* Images.xcassets */; };
 		92E39693E54735C032BC69C0 /* Pods_ZingleSDK_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE385D757B07F4CC44B4B927 /* Pods_ZingleSDK_Example.framework */; };
+		9611CD4D1E9BFEC400702465 /* ZNGMockUserClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 9611CD4C1E9BFEC400702465 /* ZNGMockUserClient.m */; };
 		961847261E96CF9500AB3D45 /* TestMessageSending.m in Sources */ = {isa = PBXBuildFile; fileRef = 961847251E96CF9500AB3D45 /* TestMessageSending.m */; };
 		9622B33A1DC284A800957C5F /* devEnterpriseService.json in Resources */ = {isa = PBXBuildFile; fileRef = 9622B3381DC284A800957C5F /* devEnterpriseService.json */; };
 		9622B3411DC2852200957C5F /* ZNGMockContactClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 9622B33E1DC2852200957C5F /* ZNGMockContactClient.m */; };
@@ -79,6 +80,8 @@
 		6003F5AF195388D20070C39A /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		960FCBAE1D0F6E9C00B7E82C /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		960FCBB21D0F6E9C00B7E82C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9611CD4B1E9BFEC400702465 /* ZNGMockUserClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ZNGMockUserClient.h; path = mocks/ZNGMockUserClient.h; sourceTree = "<group>"; };
+		9611CD4C1E9BFEC400702465 /* ZNGMockUserClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ZNGMockUserClient.m; path = mocks/ZNGMockUserClient.m; sourceTree = "<group>"; };
 		961847251E96CF9500AB3D45 /* TestMessageSending.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestMessageSending.m; sourceTree = "<group>"; };
 		9622B3381DC284A800957C5F /* devEnterpriseService.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = devEnterpriseService.json; path = data/devEnterpriseService.json; sourceTree = "<group>"; };
 		9622B33D1DC2852200957C5F /* ZNGMockContactClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ZNGMockContactClient.h; path = mocks/ZNGMockContactClient.h; sourceTree = "<group>"; };
@@ -275,6 +278,8 @@
 				9622B3581DC2BA2600957C5F /* ZNGMockServiceClient.m */,
 				9622B35E1DC2CB8400957C5F /* ZNGMockUserAuthorizationClient.h */,
 				9622B35F1DC2CB8400957C5F /* ZNGMockUserAuthorizationClient.m */,
+				9611CD4B1E9BFEC400702465 /* ZNGMockUserClient.h */,
+				9611CD4C1E9BFEC400702465 /* ZNGMockUserClient.m */,
 			);
 			name = "Mock Clients";
 			sourceTree = "<group>";
@@ -527,6 +532,7 @@
 				964E99C81DCAACA000A22CD5 /* ZNGMockNotificationsClient.m in Sources */,
 				96A05BCE1DCBA68700E0E6D8 /* TestAccountSession.m in Sources */,
 				9622B3591DC2BA2600957C5F /* ZNGMockAccountClient.m in Sources */,
+				9611CD4D1E9BFEC400702465 /* ZNGMockUserClient.m in Sources */,
 				9622B3421DC2852200957C5F /* ZNGMockContactServiceClient.m in Sources */,
 				96E0AABA1E6F87CE00911146 /* ZNGMockMessageClient.m in Sources */,
 				96EBB5691E0877900048218C /* TestTemplate.m in Sources */,

--- a/Pod/Classes/Clients/ZNGBaseClientAccount.h
+++ b/Pod/Classes/Clients/ZNGBaseClientAccount.h
@@ -1,0 +1,26 @@
+//
+//  ZNGBaseClientAccount.h
+//  Pods
+//
+//  Created by Jason Neel on 4/6/17.
+//
+//
+
+#import <ZingleSDK/ZingleSDK.h>
+
+/**
+ *  A Zingle SDK client that requires both an active account
+ */
+@interface ZNGBaseClientAccount : ZNGBaseClient
+
+NS_ASSUME_NONNULL_BEGIN
+
+@property (nonatomic, readonly, nonnull) NSString * accountId;
+
+- (instancetype) initWithSession:(__weak ZingleSession *)session accountId:(NSString *)accountId;
+
+- (instancetype) initWithSession:(__weak ZingleSession *)session NS_UNAVAILABLE;
+
+NS_ASSUME_NONNULL_END
+
+@end

--- a/Pod/Classes/Clients/ZNGBaseClientAccount.m
+++ b/Pod/Classes/Clients/ZNGBaseClientAccount.m
@@ -1,0 +1,24 @@
+//
+//  ZNGBaseClientAccount.m
+//  Pods
+//
+//  Created by Jason Neel on 4/6/17.
+//
+//
+
+#import "ZNGBaseClientAccount.h"
+
+@implementation ZNGBaseClientAccount
+
+- (id) initWithSession:(ZingleSession * _Nonnull __weak)session accountId:(NSString *)accountId
+{
+    self = [super initWithSession:session];
+    
+    if (self != nil) {
+        _accountId = [accountId copy];
+    }
+    
+    return self;
+}
+
+@end

--- a/Pod/Classes/Clients/ZNGBaseClientService.h
+++ b/Pod/Classes/Clients/ZNGBaseClientService.h
@@ -9,7 +9,7 @@
 #import "ZNGBaseClient.h"
 
 /**
- *  A Zingle SDK client that requires both an active account and service
+ *  A Zingle SDK client that requires both an active service
  */
 @interface ZNGBaseClientService : ZNGBaseClient
 

--- a/Pod/Classes/Clients/ZNGBaseClientService.h
+++ b/Pod/Classes/Clients/ZNGBaseClientService.h
@@ -9,7 +9,7 @@
 #import "ZNGBaseClient.h"
 
 /**
- *  A Zingle SDK client that requires both an active service
+ *  A Zingle SDK client that requires an active service
  */
 @interface ZNGBaseClientService : ZNGBaseClient
 

--- a/Pod/Classes/Clients/ZNGUserClient.h
+++ b/Pod/Classes/Clients/ZNGUserClient.h
@@ -1,0 +1,19 @@
+//
+//  ZNGUserClient.h
+//  Pods
+//
+//  Created by Jason Neel on 4/5/17.
+//
+//
+
+#import <ZingleSDK/ZingleSDK.h>
+
+@class ZNGUser;
+
+@interface ZNGUserClient : ZNGBaseClientService
+
+- (void) userWithId:(NSString *)userId
+            success:(void (^)(ZNGUser* user, ZNGStatus* status))success
+            failure:(void (^)(ZNGError* error))failure;
+
+@end

--- a/Pod/Classes/Clients/ZNGUserClient.h
+++ b/Pod/Classes/Clients/ZNGUserClient.h
@@ -8,6 +8,8 @@
 
 #import <ZingleSDK/ZNGBaseClientAccount.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class ZNGUser;
 
 @interface ZNGUserClient : ZNGBaseClientAccount
@@ -16,4 +18,16 @@
             success:(void (^)(ZNGUser* user, ZNGStatus* status))success
             failure:(void (^)(ZNGError* error))failure;
 
+#pragma mark - Avatars
+- (void) deleteAvatarForUserWithId:(NSString *)userId
+                           success:(void (^ _Nullable)())success
+                           failure:(void (^ _Nullable)(ZNGError * error))failure;
+
+- (void) uploadAvatar:(UIImage *)avatarImage
+        forUserWithId:(NSString *)userId
+              success:(void (^ _Nullable)())success
+              failure:(void (^ _Nullable)(ZNGError * error))failure;
+
+NS_ASSUME_NONNULL_END
+                                    
 @end

--- a/Pod/Classes/Clients/ZNGUserClient.h
+++ b/Pod/Classes/Clients/ZNGUserClient.h
@@ -6,11 +6,11 @@
 //
 //
 
-#import <ZingleSDK/ZingleSDK.h>
+#import <ZingleSDK/ZNGBaseClientAccount.h>
 
 @class ZNGUser;
 
-@interface ZNGUserClient : ZNGBaseClientService
+@interface ZNGUserClient : ZNGBaseClientAccount
 
 - (void) userWithId:(NSString *)userId
             success:(void (^)(ZNGUser* user, ZNGStatus* status))success

--- a/Pod/Classes/Clients/ZNGUserClient.m
+++ b/Pod/Classes/Clients/ZNGUserClient.m
@@ -7,6 +7,10 @@
 //
 
 #import "ZNGUserClient.h"
+#import "NSData+ImageType.h"
+#import "ZNGLogging.h"
+
+static const int zngLogLevel = ZNGLogLevelWarning;
 
 @implementation ZNGUserClient
 
@@ -14,12 +18,65 @@
             success:(void (^)(ZNGUser* user, ZNGStatus* status))success
             failure:(void (^)(ZNGError* error))failure
 {
-    NSString* path = [NSString stringWithFormat:@"accounts/%@/users/%@", self.accountId, userId];
+    NSString * path = [NSString stringWithFormat:@"accounts/%@/users/%@", self.accountId, userId];
 
     [self getWithResourcePath:path
                 responseClass:[ZNGUser class]
                       success:success
                       failure:failure];
+}
+
+- (void) deleteAvatarForUserWithId:(NSString *)userId
+                           success:(void (^)())success
+                           failure:(void (^)(ZNGError * error))failure
+{
+    NSString * path = [NSString stringWithFormat:@"accounts/%@/users/%@/avatar", self.accountId, userId];
+    
+    [self deleteWithPath:path success:^(ZNGStatus * _Nonnull status) {
+        if (success != nil) {
+            success();
+        }
+    } failure:failure];
+}
+
+- (void) uploadAvatar:(UIImage *)avatarImage
+        forUserWithId:(NSString *)userId
+              success:(void (^)())success
+              failure:(void (^)(ZNGError * error))failure
+{
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        NSData * imageData = UIImageJPEGRepresentation(avatarImage, 0.5);
+        NSString * contentType = [imageData imageContentType];
+        
+        if (([imageData length] == 0) || ([contentType length] == 0)) {
+            NSString * errorString = [NSString stringWithFormat:@"Unable to parse image data and content type from %@ image and %llu bytes",
+                                      NSStringFromCGSize(avatarImage.size), (unsigned long long)[imageData length]];
+            ZNGLogError(@"%@", errorString);
+            
+            if (failure != nil) {
+                ZNGError * error = [[ZNGError alloc] initWithDomain:kZingleErrorDomain code:0 userInfo:@{ NSLocalizedDescriptionKey: errorString }];
+                
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    failure(error);
+                });
+            }
+            
+            return;
+        }
+
+        
+        NSString * path = [NSString stringWithFormat:@"accounts/%@/users/%@/avatar", self.accountId, userId];
+        NSDictionary * parameters = @{
+                                      @"content-type": contentType,
+                                      @"base64": [imageData base64EncodedStringWithOptions:0]
+                                      };
+        
+        [self putWithPath:path parameters:parameters responseClass:nil success:^(id  _Nonnull responseObject, ZNGStatus * _Nonnull status) {
+            if (success != nil) {
+                success();
+            }
+        } failure:failure];
+    });
 }
 
 @end

--- a/Pod/Classes/Clients/ZNGUserClient.m
+++ b/Pod/Classes/Clients/ZNGUserClient.m
@@ -9,6 +9,7 @@
 #import "ZNGUserClient.h"
 #import "NSData+ImageType.h"
 #import "ZNGLogging.h"
+#import "ZingleAccountSession.h"
 
 static const int zngLogLevel = ZNGLogLevelWarning;
 
@@ -33,6 +34,8 @@ static const int zngLogLevel = ZNGLogLevelWarning;
     NSString * path = [NSString stringWithFormat:@"accounts/%@/users/%@/avatar", self.accountId, userId];
     
     [self deleteWithPath:path success:^(ZNGStatus * _Nonnull status) {
+        [self refreshUserData];
+        
         if (success != nil) {
             success();
         }
@@ -72,11 +75,20 @@ static const int zngLogLevel = ZNGLogLevelWarning;
                                       };
         
         [self putWithPath:path parameters:parameters responseClass:nil success:^(id  _Nonnull responseObject, ZNGStatus * _Nonnull status) {
+            [self refreshUserData];
+            
             if (success != nil) {
                 success();
             }
         } failure:failure];
     });
+}
+
+- (void) refreshUserData
+{
+    if ([self.session isKindOfClass:[ZingleAccountSession class]]) {
+        [(ZingleAccountSession *)self.session updateUserData];
+    }
 }
 
 @end

--- a/Pod/Classes/Clients/ZNGUserClient.m
+++ b/Pod/Classes/Clients/ZNGUserClient.m
@@ -48,7 +48,7 @@ static const int zngLogLevel = ZNGLogLevelWarning;
               failure:(void (^)(ZNGError * error))failure
 {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        NSData * imageData = UIImageJPEGRepresentation(avatarImage, 0.5);
+        NSData * imageData = UIImageJPEGRepresentation([self imageDownsizedToReasonableAvatarSize:avatarImage], 0.5);
         NSString * contentType = [imageData imageContentType];
         
         if (([imageData length] == 0) || ([contentType length] == 0)) {
@@ -82,6 +82,31 @@ static const int zngLogLevel = ZNGLogLevelWarning;
             }
         } failure:failure];
     });
+}
+
+- (UIImage *) imageDownsizedToReasonableAvatarSize:(UIImage *)originalImage
+{
+    if (originalImage == nil) {
+        return nil;
+    }
+    
+    static const CGFloat maxDimension = 800.0;
+    CGFloat widthDownscale = maxDimension / originalImage.size.width;
+    CGFloat heightDownscale = maxDimension / originalImage.size.height;
+    CGFloat downscale = MIN(widthDownscale, heightDownscale);
+    
+    if (downscale >= 1.0) {
+        return originalImage;
+    }
+    
+    CGRect rect = CGRectMake(0.0, 0.0, originalImage.size.width * downscale, originalImage.size.height * downscale);
+    UIGraphicsBeginImageContextWithOptions(rect.size, false, originalImage.scale);
+    
+    [originalImage drawInRect:rect];
+    
+    UIImage * result = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return result;
 }
 
 - (void) refreshUserData

--- a/Pod/Classes/Clients/ZNGUserClient.m
+++ b/Pod/Classes/Clients/ZNGUserClient.m
@@ -1,0 +1,25 @@
+//
+//  ZNGUserClient.m
+//  Pods
+//
+//  Created by Jason Neel on 4/5/17.
+//
+//
+
+#import "ZNGUserClient.h"
+
+@implementation ZNGUserClient
+
+- (void) userWithId:(NSString *)userId
+            success:(void (^)(ZNGUser* user, ZNGStatus* status))success
+            failure:(void (^)(ZNGError* error))failure
+{
+    NSString* path = [NSString stringWithFormat:@"services/%@/users/%@", self.accountId, userId];
+
+    [self getWithResourcePath:path
+                responseClass:[ZNGUser class]
+                      success:success
+                      failure:failure];
+}
+
+@end

--- a/Pod/Classes/Clients/ZNGUserClient.m
+++ b/Pod/Classes/Clients/ZNGUserClient.m
@@ -67,7 +67,7 @@ static const int zngLogLevel = ZNGLogLevelWarning;
         
         NSString * path = [NSString stringWithFormat:@"accounts/%@/users/%@/avatar", self.accountId, userId];
         NSDictionary * parameters = @{
-                                      @"content-type": contentType,
+                                      @"content_type": contentType,
                                       @"base64": [imageData base64EncodedStringWithOptions:0]
                                       };
         

--- a/Pod/Classes/Clients/ZNGUserClient.m
+++ b/Pod/Classes/Clients/ZNGUserClient.m
@@ -14,7 +14,7 @@
             success:(void (^)(ZNGUser* user, ZNGStatus* status))success
             failure:(void (^)(ZNGError* error))failure
 {
-    NSString* path = [NSString stringWithFormat:@"services/%@/users/%@", self.accountId, userId];
+    NSString* path = [NSString stringWithFormat:@"accounts/%@/users/%@", self.accountId, userId];
 
     [self getWithResourcePath:path
                 responseClass:[ZNGUser class]

--- a/Pod/Classes/Models/ZNGUser.h
+++ b/Pod/Classes/Models/ZNGUser.h
@@ -19,6 +19,7 @@
 @property(nonatomic, strong) NSString* lastName;
 @property(nonatomic, strong) NSString* title;
 @property(nonatomic, strong) NSArray* serviceIds;
+@property(nonatomic, strong) NSURL * avatarUri;
 
 - (NSString *) fullName;
 

--- a/Pod/Classes/Models/ZNGUser.m
+++ b/Pod/Classes/Models/ZNGUser.m
@@ -20,8 +20,14 @@
              @"firstName" : @"first_name",
              @"lastName" : @"last_name",
              @"title" : @"title",
-             @"serviceIds" : @"service_ids"
+             @"serviceIds" : @"service_ids",
+             @"avatarUri" : @"avatar_uri"
              };
+}
+
++ (NSValueTransformer *) avatarUriJSONTransformer
+{
+    return [NSValueTransformer valueTransformerForName:MTLURLValueTransformerName];
 }
 
 - (NSString *) fullName

--- a/Pod/Classes/UI/Views/ZNGAvatarImageView.h
+++ b/Pod/Classes/UI/Views/ZNGAvatarImageView.h
@@ -30,6 +30,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign) UIEdgeInsets insetsWhenEditIconPresent;
 
+/**
+ *  Corresponding read/write property to center, taking into account any edit icon and its corresponding offset on our image.
+ *  Setting this property does not move the image within our view; it moves the view itself to position the image as specified in our superview.
+ */
+@property (nonatomic, assign) CGPoint centerOfImage;
+
 // Readonly properties set on init
 @property (nonatomic, readonly, nullable) NSURL * avatarUrl;
 @property (nonatomic, readonly) NSString * initials;

--- a/Pod/Classes/UI/Views/ZNGAvatarImageView.h
+++ b/Pod/Classes/UI/Views/ZNGAvatarImageView.h
@@ -1,0 +1,43 @@
+//
+//  ZNGAvatarImageView.h
+//  Pods
+//
+//  Created by Jason Neel on 4/11/17.
+//
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ *  Subclass of UIImageView that allows an edit icon to be overlaid onto the image, adjusting intrinsicContentSize to take it into account.
+ */
+@interface ZNGAvatarImageView : UIImageView
+
+/**
+ *  If this flag is set, the edit image will be displayed on the image view, expanding its intrinsicContentSize if necessary.
+ */
+@property (nonatomic, assign) BOOL showEditIcon;
+
+/**
+ *  The image asset to be used as the edit icon
+ */
+@property (nonatomic, strong, nullable) UIImage * editIconImage;
+
+/**
+ *  How far the edit image should extend beyond the normal edges of our image.
+ */
+@property (nonatomic, assign) CGPoint editImageEdgeOverflow;
+
+
+- (id) initWithAvatarUrl:(NSURL * _Nullable)avatarUrl initials:(NSString *)initials size:(CGSize)size backgroundColor:(UIColor * _Nullable)backgroundColor textColor:(UIColor *)textColor font:(UIFont *)font;
+
+/**
+ *  Can be overridden by subclasses to move the edit icon from its default position of lower right.
+ */
+- (CGPoint) editImageLocation;
+
+NS_ASSUME_NONNULL_END
+
+@end

--- a/Pod/Classes/UI/Views/ZNGAvatarImageView.h
+++ b/Pod/Classes/UI/Views/ZNGAvatarImageView.h
@@ -26,10 +26,18 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) UIImage * editIconImage;
 
 /**
- *  How far the edit image should extend beyond the normal edges of our image.
+ *  The padding to place around the view when showEditIcon is set to YES.  Note all numbers should be negative or 0.0
  */
-@property (nonatomic, assign) CGPoint editImageEdgeOverflow;
+@property (nonatomic, assign) UIEdgeInsets insetsWhenEditIconPresent;
 
+// Readonly properties set on init
+@property (nonatomic, readonly, nullable) NSURL * avatarUrl;
+@property (nonatomic, readonly) NSString * initials;
+@property (nonatomic, readonly) CGSize size;
+@property (nonatomic, readonly, nullable) UIColor * backgroundColor;
+@property (nonatomic, readonly) UIColor * textColor;
+@property (nonatomic, readonly) UIFont * font;
+@property (nonatomic, readonly) UIImage * placeholderImage;
 
 - (id) initWithAvatarUrl:(NSURL * _Nullable)avatarUrl initials:(NSString *)initials size:(CGSize)size backgroundColor:(UIColor * _Nullable)backgroundColor textColor:(UIColor *)textColor font:(UIFont *)font;
 

--- a/Pod/Classes/UI/Views/ZNGAvatarImageView.m
+++ b/Pod/Classes/UI/Views/ZNGAvatarImageView.m
@@ -1,0 +1,118 @@
+//
+//  ZNGAvatarImageView.m
+//  Pods
+//
+//  Created by Jason Neel on 4/11/17.
+//
+//
+
+#import "ZNGAvatarImageView.h"
+#import "ZNGInitialsAvatar.h"
+
+@import SDWebImage;
+
+
+@implementation ZNGAvatarImageView
+{
+    /**
+     *  The image set before any edit icon was possibly added.
+     */
+    UIImage * _rawImage;
+}
+
+#pragma mark - Initialization
+- (id) initWithAvatarUrl:(NSURL * _Nullable)avatarUrl initials:(NSString *)initials size:(CGSize)size backgroundColor:(UIColor * _Nullable)backgroundColor textColor:(UIColor *)textColor font:(UIFont *)font;
+{
+    self = [super init];
+    
+    if (self != nil) {
+        ZNGInitialsAvatar * initialsAvatar = [[ZNGInitialsAvatar alloc] initWithInitials:initials textColor:textColor backgroundColor:backgroundColor size:size font:font];
+        UIImage * initialsImage = [initialsAvatar avatarImage];
+        
+        [self sd_setImageWithURL:avatarUrl placeholderImage:initialsImage];
+    }
+    
+    return self;
+}
+
+#pragma mark - Setters
+- (void) setShowEditIcon:(BOOL)showEditIcon
+{
+    if (self.showEditIcon == showEditIcon) {
+        return;
+    }
+    
+    _showEditIcon = showEditIcon;
+    
+    if (showEditIcon) {
+        [super setImage:[self imageAddingEditIcon:_rawImage]];
+    } else {
+        [super setImage:_rawImage];
+    }
+}
+
+- (void) setEditIconImage:(UIImage *)editIconImage
+{
+    _editIconImage = editIconImage;
+    
+    if (self.showEditIcon) {
+        // We need to re-render
+        [super setImage:[self imageAddingEditIcon:_rawImage]];
+    }
+}
+
+- (void) setImage:(UIImage *)image
+{
+    _rawImage = image;
+    UIImage * finalImage = image;
+
+    if ((self.showEditIcon) && (self.editIconImage != nil)) {
+        finalImage = [self imageAddingEditIcon:image];
+    }
+    
+    [super setImage:finalImage];
+}
+
+#pragma mark - Sizing
+- (CGSize) intrinsicContentSize
+{
+    if (!self.showEditIcon) {
+        // No edit icon = nothing special about our subclass
+        return [super intrinsicContentSize];
+    }
+
+    // Note that expandedSize adds double x and y of the overflow.  This is so our original image asset remains centered, even after adding overflow
+    //  for the edit icon.
+    CGSize superSize = [super intrinsicContentSize];
+    return CGSizeMake(superSize.width + (self.editImageEdgeOverflow.x * 2.0), superSize.height + (self.editImageEdgeOverflow.y * 2.0));
+}
+
+#pragma mark - Image manipulation
+- (UIImage *) imageAddingEditIcon:(UIImage *)image
+{
+    if ((image == nil) || (self.editIconImage == nil)) {
+        return nil;
+    }
+    
+    CGSize totalSize = [self intrinsicContentSize];
+    
+    // Draw the original image, allowing for padding
+    UIGraphicsBeginImageContextWithOptions(totalSize, false, image.scale);
+    [image drawAtPoint:self.editImageEdgeOverflow];
+    
+    // Draw the edit icon
+    [self.editIconImage drawAtPoint:[self editImageLocation]];
+    
+    UIImage * result = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return result;
+}
+
+- (CGPoint) editImageLocation
+{
+    CGSize totalSize = [self intrinsicContentSize];
+    return CGPointMake(totalSize.width - self.editIconImage.size.width, totalSize.height - self.editIconImage.size.height);
+}
+
+
+@end

--- a/Pod/Classes/UI/Views/ZNGAvatarImageView.m
+++ b/Pod/Classes/UI/Views/ZNGAvatarImageView.m
@@ -26,10 +26,20 @@
     self = [super init];
     
     if (self != nil) {
-        ZNGInitialsAvatar * initialsAvatar = [[ZNGInitialsAvatar alloc] initWithInitials:initials textColor:textColor backgroundColor:backgroundColor size:size font:font];
-        UIImage * initialsImage = [initialsAvatar avatarImage];
+        _avatarUrl = [avatarUrl copy];
+        _initials = [initials copy];
+        _size = size;
+        _backgroundColor = backgroundColor;
+        _textColor = textColor;
+        _font = font;
         
-        [self sd_setImageWithURL:avatarUrl placeholderImage:initialsImage];
+        ZNGInitialsAvatar * initialsAvatar = [[ZNGInitialsAvatar alloc] initWithInitials:initials textColor:textColor backgroundColor:backgroundColor size:size font:font];
+        _placeholderImage = [initialsAvatar avatarImage];
+        
+        self.frame = CGRectMake(0.0, 0.0, size.width, size.height);
+        self.contentMode = UIViewContentModeScaleAspectFit;
+        
+        [self sd_setImageWithURL:avatarUrl placeholderImage:_placeholderImage];
     }
     
     return self;
@@ -84,7 +94,9 @@
     // Note that expandedSize adds double x and y of the overflow.  This is so our original image asset remains centered, even after adding overflow
     //  for the edit icon.
     CGSize superSize = [super intrinsicContentSize];
-    return CGSizeMake(superSize.width + (self.editImageEdgeOverflow.x * 2.0), superSize.height + (self.editImageEdgeOverflow.y * 2.0));
+    CGFloat width = superSize.width - self.insetsWhenEditIconPresent.left - self.insetsWhenEditIconPresent.right;
+    CGFloat height = superSize.height - self.insetsWhenEditIconPresent.top - self.insetsWhenEditIconPresent.bottom;
+    return CGSizeMake(width, height);
 }
 
 #pragma mark - Image manipulation
@@ -98,7 +110,8 @@
     
     // Draw the original image, allowing for padding
     UIGraphicsBeginImageContextWithOptions(totalSize, false, image.scale);
-    [image drawAtPoint:self.editImageEdgeOverflow];
+    CGPoint originalImageOrigin = CGPointMake(-self.insetsWhenEditIconPresent.left, -self.insetsWhenEditIconPresent.top);
+    [image drawAtPoint:originalImageOrigin];
     
     // Draw the edit icon
     [self.editIconImage drawAtPoint:[self editImageLocation]];

--- a/Pod/Classes/UI/Views/ZNGAvatarImageViewVerticallyCentered.h
+++ b/Pod/Classes/UI/Views/ZNGAvatarImageViewVerticallyCentered.h
@@ -1,0 +1,13 @@
+//
+//  ZNGAvatarImageViewVerticallyCentered.h
+//  Pods
+//
+//  Created by Jason Neel on 4/12/17.
+//
+//
+
+#import "ZNGAvatarImageView.h"
+
+@interface ZNGAvatarImageViewVerticallyCentered : ZNGAvatarImageView
+
+@end

--- a/Pod/Classes/UI/Views/ZNGAvatarImageViewVerticallyCentered.m
+++ b/Pod/Classes/UI/Views/ZNGAvatarImageViewVerticallyCentered.m
@@ -1,0 +1,21 @@
+//
+//  ZNGAvatarImageViewVerticallyCentered.m
+//  Pods
+//
+//  Created by Jason Neel on 4/12/17.
+//
+//
+
+#import "ZNGAvatarImageViewVerticallyCentered.h"
+
+@implementation ZNGAvatarImageViewVerticallyCentered
+
+- (CGPoint) editImageLocation
+{
+    CGSize size = [self intrinsicContentSize];
+    CGFloat x = size.width - self.editIconImage.size.width;
+    CGFloat y = (size.height / 2.0) - (self.editIconImage.size.height / 2.0);
+    return CGPointMake(x, y);
+}
+
+@end

--- a/Pod/Classes/Utility/NSData+ImageType.h
+++ b/Pod/Classes/Utility/NSData+ImageType.h
@@ -1,0 +1,24 @@
+//
+//  NSData+ImageType.h
+//  Pods
+//
+//  Created by Jason Neel on 4/11/17.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+extern NSString * _Nonnull const NSDataImageContentTypeGif;
+extern NSString * _Nonnull const NSDataImageContentTypeJpeg;
+extern NSString * _Nonnull const NSDataImageContentTypePng;
+extern NSString * _Nonnull const NSDataImageContentTypeTiff;
+
+@interface NSData (ImageType)
+
+/**
+ *  For image data, returns a string content type of the form "image/jpeg"
+ *  For non-image data, behavior is undefined.
+ */
+- (NSString * _Nullable) imageContentType;
+
+@end

--- a/Pod/Classes/Utility/NSData+ImageType.m
+++ b/Pod/Classes/Utility/NSData+ImageType.m
@@ -1,0 +1,38 @@
+//
+//  NSData+ImageType.m
+//  Pods
+//
+//  Created by Jason Neel on 4/11/17.
+//
+//
+
+#import "NSData+ImageType.h"
+
+NSString * const NSDataImageContentTypeGif = @"image/gif";
+NSString * const NSDataImageContentTypeJpeg = @"image/jpeg";
+NSString * const NSDataImageContentTypePng = @"image/png";
+NSString * const NSDataImageContentTypeTiff = @"image/tiff";
+
+@implementation NSData (ImageType)
+
+- (NSString * _Nullable) imageContentType;
+{
+    uint8_t firstChar;
+    [self getBytes:&firstChar length:1];
+    
+    switch (firstChar) {
+        case 0xFF:
+            return NSDataImageContentTypeJpeg;
+        case 0x89:
+            return NSDataImageContentTypePng;
+        case 0x47:
+            return NSDataImageContentTypeGif;
+        case 0x49:
+        case 0x4D:
+            return NSDataImageContentTypeTiff;
+        default:
+            return nil;
+    }
+}
+
+@end

--- a/Pod/Classes/ZingleAccountSession.h
+++ b/Pod/Classes/ZingleAccountSession.h
@@ -102,6 +102,9 @@ extern NSString * const ZingleUserChangedDetailedEventsPreferenceNotification;
 
 - (void) connectWithAccountChooser:(nullable ZNGAccountChooser)accountChooser serviceChooser:(nullable ZNGServiceChooser)serviceChooser completion:(nullable ZNGAccountSessionCallback)completion;
 
+#pragma mark - User data
+- (void) updateUserData;
+
 #pragma mark - Messaging methods
 
 /**

--- a/Pod/Classes/ZingleAccountSession.h
+++ b/Pod/Classes/ZingleAccountSession.h
@@ -19,6 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class ZNGServiceToContactViewController;
 @class ZNGContactEditViewController;
 @class ZNGUserAuthorization;
+@class ZNGUserClient;
 
 /**
  *  Notification name posted with an NSNumber bool as the object when the user switches to or from detailed event viewing
@@ -54,6 +55,7 @@ extern NSString * const ZingleUserChangedDetailedEventsPreferenceNotification;
  *  Meta data about the current user.
  */
 @property (nonatomic, strong, nullable) ZNGUserAuthorization * userAuthorization;
+@property (nonatomic, strong, nullable) ZNGUser * user;
 
 /**
  *  If set, the service object will be refreshed whenever returning from the background (but no more often than every ten minutes.)
@@ -82,8 +84,9 @@ extern NSString * const ZingleUserChangedDetailedEventsPreferenceNotification;
 @property (nonatomic, copy, nullable) ZNGAccountSessionCallback completion;
 
 #pragma mark - Clients
-@property (nonatomic, strong, nonnull) ZNGAutomationClient * automationClient;
-@property (nonatomic, strong, nonnull) ZNGLabelClient * labelClient;
+@property (nonatomic, strong, nullable) ZNGAutomationClient * automationClient;
+@property (nonatomic, strong, nullable) ZNGLabelClient * labelClient;
+@property (nonatomic, strong, nullable) ZNGUserClient * userClient;
 
 /**
  *  If this flag is set, all conversation objects provided by this session will be detailed event conversations.

--- a/Pod/Classes/ZingleAccountSession.m
+++ b/Pod/Classes/ZingleAccountSession.m
@@ -420,6 +420,13 @@ NSString * const ZingleUserChangedDetailedEventsPreferenceNotification = @"Zingl
     [self _registerForPushNotificationsForServiceIds:@[serviceId] removePreviousSubscriptions:YES];
 }
 
+- (void) updateUserData
+{
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        [self synchronouslyRetrieveUserData];
+    });
+}
+
 /**
  *  Retrieve ZNGUserAuthorization and ZNGUser objects.  Method returns once both requests complete.
  */

--- a/Pod/Classes/ZingleAccountSession.m
+++ b/Pod/Classes/ZingleAccountSession.m
@@ -407,7 +407,12 @@ NSString * const ZingleUserChangedDetailedEventsPreferenceNotification = @"Zingl
     self.labelClient = [[ZNGLabelClient alloc] initWithSession:self serviceId:serviceId];
     self.eventClient = [[ZNGEventClient alloc] initWithSession:self serviceId:serviceId];
     self.messageClient = [[ZNGMessageClient alloc] initWithSession:self serviceId:serviceId];
-    self.userClient = [[ZNGUserClient alloc] initWithSession:self accountId:self.account.accountId];
+    
+    // A lazy way to keep us from overwriting a mocked client in unit tests.
+    // This is a bit of a code smell :(
+    if (![self.userClient.accountId isEqualToString:self.account.accountId]) {
+        self.userClient = [[ZNGUserClient alloc] initWithSession:self accountId:self.account.accountId];
+    }
     
     self.socketClient = [[ZNGSocketClient alloc] initWithSession:self];
     [self.socketClient connect];


### PR DESCRIPTION
- Added ZNGUserClient to retrieve user data, including avatars, from the new /users/ end point
- Modified account session to wait until retrieving said user data before completing login
- Modified account session unit tests to check for the above
- Added avatar PUT/DELETE to ZNGUserClient
- Moved logic for determining image file type from the one place it was used (attaching images to messages) into an NSData category so that it can be used for avatar uploads
- Created an avatar UIImageView subclass that allows an optional icon to be superimposed over the avatar and handles both downloading remote images for avatars and using an initials avatar as a fallback
