### PR TITLE
IOS-479: Socket connection monitoring and network status text

### DIFF
--- a/Pod/Classes/Clients/ZNGSocketClient.m
+++ b/Pod/Classes/Clients/ZNGSocketClient.m
@@ -167,6 +167,10 @@ static const int zngLogLevel = ZNGLogLevelWarning;
         [weakSelf socketDidEncounterErrorWithData:data];
     }];
     
+    [socketClient on:@"reconnect" callback:^(NSArray * _Nonnull data, SocketAckEmitter * _Nonnull ackEmitter) {
+        [weakSelf socketReconnecting];
+    }];
+    
     [socketClient on:@"disconnect" callback:^(NSArray * _Nonnull data, SocketAckEmitter * _Nonnull ackEmitter) {
         [weakSelf socketDidDisconnect];
     }];
@@ -306,9 +310,15 @@ static const int zngLogLevel = ZNGLogLevelWarning;
     }
 }
 
+- (void) socketReconnecting
+{
+    self.connected = NO;
+}
+
 - (void) socketDidDisconnect
 {
     ZNGLogInfo(@"Web socket disconnected");
+    self.connected = NO;
 }
 
 - (void) feedLocked:(NSArray *)data

--- a/Pod/Classes/Clients/ZNGSocketClient.m
+++ b/Pod/Classes/Clients/ZNGSocketClient.m
@@ -23,6 +23,10 @@ static const int zngLogLevel = ZNGLogLevelInfo;
 static const int zngLogLevel = ZNGLogLevelWarning;
 #endif
 
+@interface ZNGSocketClient()
+@property (nonatomic, assign) BOOL connected;
+@end
+
 @implementation ZNGSocketClient
 {
     SocketIOClient * socketClient;
@@ -70,11 +74,6 @@ static const int zngLogLevel = ZNGLogLevelWarning;
 - (BOOL) active
 {
     return ((socketClient.status == SocketIOClientStatusConnected) || (socketClient.status == SocketIOClientStatusConnecting) || (initializingSession));
-}
-
-- (BOOL) connected
-{
-    return (socketClient.status == SocketIOClientStatusConnected);
 }
 
 - (void) setActiveConversation:(ZNGConversation *)activeConversation
@@ -256,6 +255,7 @@ static const int zngLogLevel = ZNGLogLevelWarning;
     authFailureCount = 0;
     [authRetryTimer invalidate];
     authRetryTimer = nil;
+    self.connected = YES;
     
     ZNGLogInfo(@"Web socket connected.");
     [socketClient emit:@"bindNodeController" with:@[@"dashboard.inbox"]];

--- a/Pod/Classes/NetworkDiagnostics/ZNGNetworkLookout.h
+++ b/Pod/Classes/NetworkDiagnostics/ZNGNetworkLookout.h
@@ -1,0 +1,37 @@
+//
+//  ZNGNetworkLookout.h
+//  Pods
+//
+//  Created by Jason Neel on 4/18/17.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@class ZingleAccountSession;
+
+typedef enum {
+    ZNGNetworkStatusUnknown,
+    ZNGNetworkStatusInternetUnreachable,
+    ZNGNetworkStatusZingleAPIUnreachable,
+    ZNGNetworkStatusZingleSocketDisconnected,
+    ZNGNetworkStatusConnected
+} ZNGNetworkLookoutStatus;
+
+/**
+ *  The Network Lookout receives notifications for all networking events in the Zingle API and reports network status.
+ */
+@interface ZNGNetworkLookout : NSObject
+
+- (void) recordLogin;
+- (void) recordSocketConnected;
+- (void) recordSocketDisconnected;
+
+/**
+ *  Setting this weak session reference allows better diagnostics, especially when returning from the background.
+ */
+@property (nonatomic, weak, nullable) ZingleAccountSession * session;
+
+@property (nonatomic, readonly) ZNGNetworkLookoutStatus status;
+
+@end

--- a/Pod/Classes/NetworkDiagnostics/ZNGNetworkLookout.m
+++ b/Pod/Classes/NetworkDiagnostics/ZNGNetworkLookout.m
@@ -31,9 +31,8 @@ static const int zngLogLevel = ZNGLogLevelDebug;
 {
     if (_status != status) {
         ZNGLogDebug(@"Status changing from %@ to %@", [self debugDescriptionForStatus:_status], [self debugDescriptionForStatus:status]);
+        _status = status;
     }
-    
-    _status = status;
 }
 
 - (NSString *) debugDescriptionForStatus:(ZNGNetworkLookoutStatus)status

--- a/Pod/Classes/NetworkDiagnostics/ZNGNetworkLookout.m
+++ b/Pod/Classes/NetworkDiagnostics/ZNGNetworkLookout.m
@@ -20,11 +20,37 @@
 
 static const NSTimeInterval delayAfterLoginBeforeCheckingSocket = 3.0;
 
-static const int zngLogLevel = ZNGLogLevelInfo;
+static const int zngLogLevel = ZNGLogLevelDebug;
 
 @implementation ZNGNetworkLookout
 {
     NSTimer * checkSocketAfterDelayTimer;
+}
+
+- (void) setStatus:(ZNGNetworkLookoutStatus)status
+{
+    if (_status != status) {
+        ZNGLogDebug(@"Status changing from %@ to %@", [self debugDescriptionForStatus:_status], [self debugDescriptionForStatus:status]);
+    }
+    
+    _status = status;
+}
+
+- (NSString *) debugDescriptionForStatus:(ZNGNetworkLookoutStatus)status
+{
+    switch (status) {
+        case ZNGNetworkStatusConnected:
+            return @"Connected";
+        case ZNGNetworkStatusZingleAPIUnreachable:
+            return @"API unreachable";
+        case ZNGNetworkStatusInternetUnreachable:
+            return @"Internet unreachable";
+        case ZNGNetworkStatusZingleSocketDisconnected:
+            return @"Socket disconnected";
+        case ZNGNetworkStatusUnknown:
+        default:
+            return @"Unknown";
+    }
 }
 
 #pragma mark - Status changes

--- a/Pod/Classes/NetworkDiagnostics/ZNGNetworkLookout.m
+++ b/Pod/Classes/NetworkDiagnostics/ZNGNetworkLookout.m
@@ -1,0 +1,118 @@
+//
+//  ZNGNetworkLookout.m
+//  Pods
+//
+//  Created by Jason Neel on 4/18/17.
+//
+//
+
+#import "ZNGNetworkLookout.h"
+#import "ZingleAccountSession.h"
+#import "ZNGSocketClient.h"
+#import "ZNGLogging.h"
+#import "ZNGReachability.h"
+#import "ZNGUserAuthorizationClient.h"
+
+// Override the readonly status property so we get a free KVO setter
+@interface ZNGNetworkLookout()
+@property (nonatomic, assign) ZNGNetworkLookoutStatus status;
+@end
+
+static const NSTimeInterval delayAfterLoginBeforeCheckingSocket = 3.0;
+
+static const int zngLogLevel = ZNGLogLevelInfo;
+
+@implementation ZNGNetworkLookout
+{
+    NSTimer * checkSocketAfterDelayTimer;
+}
+
+#pragma mark - Status changes
+- (void) recordLogin
+{
+    // Set status to connected.  This will allow the socket connection some time to connect.
+    self.status = ZNGNetworkStatusConnected;
+    
+    // If our socket server has not yet connected (likely,) we will delay and then check it again before marking failure
+    if (!self.session.socketClient.connected) {
+        [self checkSocketAfterDelay];
+    }
+}
+
+- (void) checkSocketAfterDelay
+{
+    [checkSocketAfterDelayTimer invalidate];
+    checkSocketAfterDelayTimer = [NSTimer scheduledTimerWithTimeInterval:delayAfterLoginBeforeCheckingSocket
+                                                                  target:self
+                                                                selector:@selector(checkSocketConnectionSomeTimeAfterLogin:)
+                                                                userInfo:nil
+                                                                 repeats:NO];
+}
+
+- (void) checkSocketConnectionSomeTimeAfterLogin:(NSTimer *)timer
+{
+    checkSocketAfterDelayTimer = nil;
+    
+    if (self.session == nil) {
+        ZNGLogInfo(@"We do not have a session object set, so we are unable to verify socket server status.");
+        return;
+    }
+    
+    if (self.session.socketClient.connected) {
+        // Looks like we recovered.  Hooray!
+        self.status = ZNGNetworkStatusConnected;
+        return;
+    }
+    
+    // We have a problem.  Diagnose and report.
+    [self diagnoseFailure];
+}
+
+- (void) recordSocketConnected
+{
+    // Everything is great now!
+    self.status = ZNGNetworkStatusConnected;
+    
+    [checkSocketAfterDelayTimer invalidate];
+    checkSocketAfterDelayTimer = nil;
+}
+
+- (void) recordSocketDisconnected
+{
+    // If we do not have a session object set, we have to immediately mark this as a problem (since we are unable to recheck in a moment.)
+    if (self.session == nil) {
+        ZNGLogInfo(@"Socket disconnected.  We do not have a session weak reference, so this is immediately being marked as a connection failure.");
+        [self diagnoseFailure];
+        return;
+    }
+    
+    // We do have a session, so we will delay a moment to give the socket a chance to recover
+    [self checkSocketAfterDelay];
+}
+
+#pragma mark - Diagnosis
+- (void) diagnoseFailure
+{
+    // Do they even have internet access?
+    ZNGReachability * internetReachability = [ZNGReachability reachabilityForInternetConnection];
+    
+    if ([internetReachability currentReachabilityStatus] == NotReachable) {
+        self.status = ZNGNetworkStatusInternetUnreachable;
+        return;
+    }
+    
+    // They have internet access.  We will first mark this as a socket connection failure.
+    self.status = ZNGNetworkStatusZingleSocketDisconnected;
+    
+    // We will then check if we can even reach the API
+    if (self.session.userAuthorizationClient != nil) {
+        [self.session.userAuthorizationClient userAuthorizationWithSuccess:^(ZNGUserAuthorization *userAuthorization, ZNGStatus *status) {
+            ZNGLogInfo(@"We are still able to reach the API.  This looks like a socket only problem.  Leaving status as Socket Disconnected.");
+        } failure:^(ZNGError *error) {
+            ZNGLogInfo(@"Unable to reach Zingle API: %@", error);
+            self.status = ZNGNetworkStatusZingleAPIUnreachable;
+        }];
+    }
+}
+
+@end

--- a/Pod/Classes/NetworkDiagnostics/ZNGReachability.h
+++ b/Pod/Classes/NetworkDiagnostics/ZNGReachability.h
@@ -1,0 +1,64 @@
+/*
+ Copyright (C) 2016 Apple Inc. All Rights Reserved.
+ See LICENSE.txt for this sample’s licensing information
+ 
+ Abstract:
+ Basic demonstration of how to use the SystemConfiguration Reachablity APIs.
+ */
+
+#import <Foundation/Foundation.h>
+#import <SystemConfiguration/SystemConfiguration.h>
+#import <netinet/in.h>
+
+
+typedef enum : NSInteger {
+	NotReachable = 0,
+	ReachableViaWiFi,
+	ReachableViaWWAN
+} NetworkStatus;
+
+#pragma mark IPv6 Support
+//Reachability fully support IPv6.  For full details, see ReadMe.md.
+
+
+extern NSString *kReachabilityChangedNotification;
+
+
+@interface ZNGReachability : NSObject
+
+/*!
+ * Use to check the reachability of a given host name.
+ */
++ (instancetype)reachabilityWithHostName:(NSString *)hostName;
+
+/*!
+ * Use to check the reachability of a given IP address.
+ */
++ (instancetype)reachabilityWithAddress:(const struct sockaddr *)hostAddress;
+
+/*!
+ * Checks whether the default route is available. Should be used by applications that do not connect to a particular host.
+ */
++ (instancetype)reachabilityForInternetConnection;
+
+
+#pragma mark reachabilityForLocalWiFi
+//reachabilityForLocalWiFi has been removed from the sample.  See ReadMe.md for more information.
+//+ (instancetype)reachabilityForLocalWiFi;
+
+/*!
+ * Start listening for reachability notifications on the current run loop.
+ */
+- (BOOL)startNotifier;
+- (void)stopNotifier;
+
+- (NetworkStatus)currentReachabilityStatus;
+
+/*!
+ * WWAN may be available, but not active until a connection has been established. WiFi may require a connection for VPN on Demand.
+ */
+- (BOOL)connectionRequired;
+
+@end
+
+

--- a/Pod/Classes/NetworkDiagnostics/ZNGReachability.m
+++ b/Pod/Classes/NetworkDiagnostics/ZNGReachability.m
@@ -1,0 +1,242 @@
+/*
+ Copyright (C) 2016 Apple Inc. All Rights Reserved.
+ See LICENSE.txt for this sample’s licensing information
+ 
+ Abstract:
+ Basic demonstration of how to use the SystemConfiguration Reachablity APIs.
+ */
+
+#import <arpa/inet.h>
+#import <ifaddrs.h>
+#import <netdb.h>
+#import <sys/socket.h>
+#import <netinet/in.h>
+
+#import <CoreFoundation/CoreFoundation.h>
+
+#import "ZNGReachability.h"
+
+#pragma mark IPv6 Support
+//Reachability fully support IPv6.  For full details, see ReadMe.md.
+
+
+NSString *kReachabilityChangedNotification = @"kNetworkReachabilityChangedNotification";
+
+
+#pragma mark - Supporting functions
+
+#define kShouldPrintReachabilityFlags 1
+
+static void PrintReachabilityFlags(SCNetworkReachabilityFlags flags, const char* comment)
+{
+#if kShouldPrintReachabilityFlags
+
+    NSLog(@"Reachability Flag Status: %c%c %c%c%c%c%c%c%c %s\n",
+          (flags & kSCNetworkReachabilityFlagsIsWWAN)				? 'W' : '-',
+          (flags & kSCNetworkReachabilityFlagsReachable)            ? 'R' : '-',
+
+          (flags & kSCNetworkReachabilityFlagsTransientConnection)  ? 't' : '-',
+          (flags & kSCNetworkReachabilityFlagsConnectionRequired)   ? 'c' : '-',
+          (flags & kSCNetworkReachabilityFlagsConnectionOnTraffic)  ? 'C' : '-',
+          (flags & kSCNetworkReachabilityFlagsInterventionRequired) ? 'i' : '-',
+          (flags & kSCNetworkReachabilityFlagsConnectionOnDemand)   ? 'D' : '-',
+          (flags & kSCNetworkReachabilityFlagsIsLocalAddress)       ? 'l' : '-',
+          (flags & kSCNetworkReachabilityFlagsIsDirect)             ? 'd' : '-',
+          comment
+          );
+#endif
+}
+
+
+static void ReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReachabilityFlags flags, void* info)
+{
+#pragma unused (target, flags)
+	NSCAssert(info != NULL, @"info was NULL in ReachabilityCallback");
+	NSCAssert([(__bridge NSObject*) info isKindOfClass: [ZNGReachability class]], @"info was wrong class in ReachabilityCallback");
+
+    ZNGReachability* noteObject = (__bridge ZNGReachability *)info;
+    // Post a notification to notify the client that the network reachability changed.
+    [[NSNotificationCenter defaultCenter] postNotificationName: kReachabilityChangedNotification object: noteObject];
+}
+
+
+#pragma mark - Reachability implementation
+
+@implementation ZNGReachability
+{
+	SCNetworkReachabilityRef _reachabilityRef;
+}
+
++ (instancetype)reachabilityWithHostName:(NSString *)hostName
+{
+	ZNGReachability* returnValue = NULL;
+	SCNetworkReachabilityRef reachability = SCNetworkReachabilityCreateWithName(NULL, [hostName UTF8String]);
+	if (reachability != NULL)
+	{
+		returnValue= [[self alloc] init];
+		if (returnValue != NULL)
+		{
+			returnValue->_reachabilityRef = reachability;
+		}
+        else {
+            CFRelease(reachability);
+        }
+	}
+	return returnValue;
+}
+
+
++ (instancetype)reachabilityWithAddress:(const struct sockaddr *)hostAddress
+{
+	SCNetworkReachabilityRef reachability = SCNetworkReachabilityCreateWithAddress(kCFAllocatorDefault, hostAddress);
+
+	ZNGReachability* returnValue = NULL;
+
+	if (reachability != NULL)
+	{
+		returnValue = [[self alloc] init];
+		if (returnValue != NULL)
+		{
+			returnValue->_reachabilityRef = reachability;
+		}
+        else {
+            CFRelease(reachability);
+        }
+	}
+	return returnValue;
+}
+
+
++ (instancetype)reachabilityForInternetConnection
+{
+	struct sockaddr_in zeroAddress;
+	bzero(&zeroAddress, sizeof(zeroAddress));
+	zeroAddress.sin_len = sizeof(zeroAddress);
+	zeroAddress.sin_family = AF_INET;
+    
+    return [self reachabilityWithAddress: (const struct sockaddr *) &zeroAddress];
+}
+
+#pragma mark reachabilityForLocalWiFi
+//reachabilityForLocalWiFi has been removed from the sample.  See ReadMe.md for more information.
+//+ (instancetype)reachabilityForLocalWiFi
+
+
+
+#pragma mark - Start and stop notifier
+
+- (BOOL)startNotifier
+{
+	BOOL returnValue = NO;
+	SCNetworkReachabilityContext context = {0, (__bridge void *)(self), NULL, NULL, NULL};
+
+	if (SCNetworkReachabilitySetCallback(_reachabilityRef, ReachabilityCallback, &context))
+	{
+		if (SCNetworkReachabilityScheduleWithRunLoop(_reachabilityRef, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode))
+		{
+			returnValue = YES;
+		}
+	}
+    
+	return returnValue;
+}
+
+
+- (void)stopNotifier
+{
+	if (_reachabilityRef != NULL)
+	{
+		SCNetworkReachabilityUnscheduleFromRunLoop(_reachabilityRef, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+	}
+}
+
+
+- (void)dealloc
+{
+	[self stopNotifier];
+	if (_reachabilityRef != NULL)
+	{
+		CFRelease(_reachabilityRef);
+	}
+}
+
+
+#pragma mark - Network Flag Handling
+
+- (NetworkStatus)networkStatusForFlags:(SCNetworkReachabilityFlags)flags
+{
+	PrintReachabilityFlags(flags, "networkStatusForFlags");
+	if ((flags & kSCNetworkReachabilityFlagsReachable) == 0)
+	{
+		// The target host is not reachable.
+		return NotReachable;
+	}
+
+    NetworkStatus returnValue = NotReachable;
+
+	if ((flags & kSCNetworkReachabilityFlagsConnectionRequired) == 0)
+	{
+		/*
+         If the target host is reachable and no connection is required then we'll assume (for now) that you're on Wi-Fi...
+         */
+		returnValue = ReachableViaWiFi;
+	}
+
+	if ((((flags & kSCNetworkReachabilityFlagsConnectionOnDemand ) != 0) ||
+        (flags & kSCNetworkReachabilityFlagsConnectionOnTraffic) != 0))
+	{
+        /*
+         ... and the connection is on-demand (or on-traffic) if the calling application is using the CFSocketStream or higher APIs...
+         */
+
+        if ((flags & kSCNetworkReachabilityFlagsInterventionRequired) == 0)
+        {
+            /*
+             ... and no [user] intervention is needed...
+             */
+            returnValue = ReachableViaWiFi;
+        }
+    }
+
+	if ((flags & kSCNetworkReachabilityFlagsIsWWAN) == kSCNetworkReachabilityFlagsIsWWAN)
+	{
+		/*
+         ... but WWAN connections are OK if the calling application is using the CFNetwork APIs.
+         */
+		returnValue = ReachableViaWWAN;
+	}
+    
+	return returnValue;
+}
+
+
+- (BOOL)connectionRequired
+{
+	NSAssert(_reachabilityRef != NULL, @"connectionRequired called with NULL reachabilityRef");
+	SCNetworkReachabilityFlags flags;
+
+	if (SCNetworkReachabilityGetFlags(_reachabilityRef, &flags))
+	{
+		return (flags & kSCNetworkReachabilityFlagsConnectionRequired);
+	}
+
+    return NO;
+}
+
+
+- (NetworkStatus)currentReachabilityStatus
+{
+	NSAssert(_reachabilityRef != NULL, @"currentNetworkStatus called with NULL SCNetworkReachabilityRef");
+	NetworkStatus returnValue = NotReachable;
+	SCNetworkReachabilityFlags flags;
+    
+	if (SCNetworkReachabilityGetFlags(_reachabilityRef, &flags))
+	{
+        returnValue = [self networkStatusForFlags:flags];
+	}
+    
+	return returnValue;
+}
+
+
+@end

--- a/Pod/Classes/UI/Categories/UILabel+NetworkStatus.h
+++ b/Pod/Classes/UI/Categories/UILabel+NetworkStatus.h
@@ -1,0 +1,16 @@
+//
+//  UILabel+NetworkStatus.h
+//  Pods
+//
+//  Created by Jason Neel on 4/18/17.
+//
+//
+
+#import <UIKit/UIKit.h>
+#import "ZNGNetworkLookout.h"
+
+@interface UILabel (NetworkStatus)
+
+- (void) updateWithNetworkStatus:(ZNGNetworkLookoutStatus)status;
+
+@end

--- a/Pod/Classes/UI/Categories/UILabel+NetworkStatus.m
+++ b/Pod/Classes/UI/Categories/UILabel+NetworkStatus.m
@@ -10,8 +10,6 @@
 
 @implementation UILabel (NetworkStatus)
 
-
-
 - (void) updateWithNetworkStatus:(ZNGNetworkLookoutStatus)status
 {
     switch (status) {

--- a/Pod/Classes/UI/Categories/UILabel+NetworkStatus.m
+++ b/Pod/Classes/UI/Categories/UILabel+NetworkStatus.m
@@ -1,0 +1,41 @@
+//
+//  UILabel+NetworkStatus.m
+//  Pods
+//
+//  Created by Jason Neel on 4/18/17.
+//
+//
+
+#import "UILabel+NetworkStatus.h"
+
+@implementation UILabel (NetworkStatus)
+
+
+
+- (void) updateWithNetworkStatus:(ZNGNetworkLookoutStatus)status
+{
+    switch (status) {
+        case ZNGNetworkStatusUnknown:
+        case ZNGNetworkStatusConnected:
+            self.text = nil;
+            return;
+            
+        case ZNGNetworkStatusZingleSocketDisconnected:
+            self.backgroundColor = [UIColor colorWithRed:0.7254902124 green:0.4784313738 blue:0.09803921729 alpha:1.0];
+            self.text = @"Partially disconnected: Things may be slow. 🐢";
+            return;
+            
+        case ZNGNetworkStatusInternetUnreachable:
+            self.backgroundColor = [UIColor colorWithRed:0.521568656 green:0.1098039225 blue:0.05098039284 alpha:1.0];
+            self.text = @"Disconnected: We're having trouble finding an internet connection. 🌎";
+            return;
+            
+        case ZNGNetworkStatusZingleAPIUnreachable:
+            self.backgroundColor = [UIColor colorWithRed:0.521568656 green:0.1098039225 blue:0.05098039284 alpha:1.0];
+            self.text = @"Disconnected: We're having trouble connecting to Zingle. 😰";
+            return;
+    }
+}
+
+@end
+

--- a/Pod/Classes/ZingleAccountSession.h
+++ b/Pod/Classes/ZingleAccountSession.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class ZNGContactEditViewController;
 @class ZNGUserAuthorization;
 @class ZNGUserClient;
+@class ZNGNetworkLookout;
 
 /**
  *  Notification name posted with an NSNumber bool as the object when the user switches to or from detailed event viewing
@@ -87,6 +88,9 @@ extern NSString * const ZingleUserChangedDetailedEventsPreferenceNotification;
 @property (nonatomic, strong, nullable) ZNGAutomationClient * automationClient;
 @property (nonatomic, strong, nullable) ZNGLabelClient * labelClient;
 @property (nonatomic, strong, nullable) ZNGUserClient * userClient;
+
+#pragma mark - Network diagnostics
+@property (nonatomic, strong, nullable) ZNGNetworkLookout * networkLookout;
 
 /**
  *  If this flag is set, all conversation objects provided by this session will be detailed event conversations.


### PR DESCRIPTION
http://jira.zinglecorp.com:8080/browse/IOS-479

- Added a network lookout class to monitor connection status and diagnose healthy vs. no internet connection vs. API unreachable vs. socket connection itself is misbehaving.
- Added a UILabel extension to set network status text consistently in any view that wishes to do so
- Added that UILabel to the conversation views.