### PR TITLE
IOS-618: Trust the server regarding label colors again

### DIFF
--- a/Pod/Classes/UI/Views/ZNGLabelCollectionViewCell.m
+++ b/Pod/Classes/UI/Views/ZNGLabelCollectionViewCell.m
@@ -32,10 +32,9 @@
 {
     NSString * paddedText = [NSString stringWithFormat:@" %@ ", [label.displayName uppercaseString]];
     self.label.text = paddedText;
-    UIColor * color = label.backgroundUIColor;
-    self.label.textColor = color;
-    self.label.borderColor = color;
-    self.label.backgroundColor = [color zng_colorByLighteningColor:0.5];
+    self.label.textColor = [label textUIColor];
+    self.label.borderColor = [label textUIColor];
+    self.label.backgroundColor = [label backgroundUIColor];
     [self.contentView setNeedsLayout];
 }
 

--- a/Pod/Classes/UI/Views/ZNGLabelGridView.m
+++ b/Pod/Classes/UI/Views/ZNGLabelGridView.m
@@ -211,12 +211,12 @@ static const int zngLogLevel = ZNGLogLevelWarning;
             [text appendAttributedString:oneSpaceString];
         }
         
-        UIColor * color = [label backgroundUIColor];
+        UIColor * textColor = [label textUIColor];
         labelView.font = self.font;
-        labelView.textColor = color;
-        labelView.borderColor = color;
-        labelView.backgroundColor = [color zng_colorByLighteningColor:0.5];
-        [text addAttribute:NSForegroundColorAttributeName value:color range:NSMakeRange(0, [text length])];
+        labelView.textColor = textColor;
+        labelView.borderColor = textColor;
+        labelView.backgroundColor = [label backgroundUIColor];
+        [text addAttribute:NSForegroundColorAttributeName value:textColor range:NSMakeRange(0, [text length])];
         labelView.attributedText = text;
         
         UITapGestureRecognizer * tapper = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tappedLabel:)];


### PR DESCRIPTION
http://jira.zinglecorp.com:8080/browse/IOS-618

Stopped lightening the background color and using the background color as text color.  Now text color (and border color) are text color, and background color is background color.

&nbsp;
&nbsp;
&nbsp;
&nbsp;
&nbsp;&nbsp;&nbsp;&nbsp;🖌 
🎨 