### PR TITLE
IOS-479: Visual tweaks to network status message

### DIFF
--- a/Pod/Classes/UI/Categories/UIColor+ZingleSDK.h
+++ b/Pod/Classes/UI/Categories/UIColor+ZingleSDK.h
@@ -33,6 +33,8 @@
 
 + (UIColor *)zng_unconfirmedMessageRed;
 
++ (UIColor *)zng_errorMessageBackgroundColor;
+
 /**
  *  @return A color object containing HSB values similar to the Zingle dashboard light gray bubble color.
  */

--- a/Pod/Classes/UI/Categories/UIColor+ZingleSDK.m
+++ b/Pod/Classes/UI/Categories/UIColor+ZingleSDK.m
@@ -29,6 +29,11 @@
                            alpha:1.0f];
 }
 
++ (UIColor *)zng_errorMessageBackgroundColor
+{
+    return [UIColor colorFromHexString:@"#2e3c54"];
+}
+
 + (UIColor *)zng_outgoingMessageBubbleColor
 {
     return [UIColor colorFromHexString:@"#00A0DE"];

--- a/Pod/Classes/UI/Categories/UILabel+NetworkStatus.m
+++ b/Pod/Classes/UI/Categories/UILabel+NetworkStatus.m
@@ -7,6 +7,7 @@
 //
 
 #import "UILabel+NetworkStatus.h"
+#import "UIColor+ZingleSDK.h"
 
 @implementation UILabel (NetworkStatus)
 
@@ -19,18 +20,18 @@
             return;
             
         case ZNGNetworkStatusZingleSocketDisconnected:
-            self.backgroundColor = [UIColor colorWithRed:0.7254902124 green:0.4784313738 blue:0.09803921729 alpha:1.0];
-            self.text = @"Partially disconnected: Things may be slow. 🐢";
+            self.backgroundColor = [UIColor zng_errorMessageBackgroundColor];
+            self.text = @"We're experiencing connection issues; things may be slow. 🐢";
             return;
             
         case ZNGNetworkStatusInternetUnreachable:
-            self.backgroundColor = [UIColor colorWithRed:0.521568656 green:0.1098039225 blue:0.05098039284 alpha:1.0];
-            self.text = @"Disconnected: We're having trouble finding an internet connection. 🌎";
+            self.backgroundColor = [UIColor zng_errorMessageBackgroundColor];
+            self.text = @"We're having trouble finding an internet connection. 🌎";
             return;
             
         case ZNGNetworkStatusZingleAPIUnreachable:
-            self.backgroundColor = [UIColor colorWithRed:0.521568656 green:0.1098039225 blue:0.05098039284 alpha:1.0];
-            self.text = @"Disconnected: We're having trouble connecting to Zingle. 😰";
+            self.backgroundColor = [UIColor zng_errorMessageBackgroundColor];
+            self.text = @"We're having trouble connecting to Zingle. 😰";
             return;
     }
 }

--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -30,6 +30,7 @@
 #import "ZNGEventViewModel.h"
 #import "ZNGUserAuthorization.h"
 #import "UILabel+NetworkStatus.h"
+#import "ZNGPaddedLabel.h"
 
 @import SDWebImage;
 
@@ -67,7 +68,7 @@ static void * KVOContext = &KVOContext;
     NSLayoutConstraint * blockedChannelOnScreenConstraint;
     NSLayoutConstraint * blockedChannelOffScreenConstraint;
     
-    UILabel * networkStatusLabel;
+    ZNGPaddedLabel * networkStatusLabel;
     
     dispatch_source_t emphasizeTimer;
     
@@ -208,7 +209,8 @@ static void * KVOContext = &KVOContext;
     self.automationLabel.userInteractionEnabled = YES;
     
     // Network status label
-    networkStatusLabel = [[UILabel alloc] init];
+    networkStatusLabel = [[ZNGPaddedLabel alloc] init];
+    networkStatusLabel.textInsets = UIEdgeInsetsMake(5.0, 0.0, 5.0, 0.0);
     networkStatusLabel.font = [UIFont latoFontOfSize:11.0];
     networkStatusLabel.textColor = [UIColor whiteColor];
     networkStatusLabel.textAlignment = NSTextAlignmentCenter;

--- a/Pod/Classes/UI/Views/ZNGPaddedLabel.h
+++ b/Pod/Classes/UI/Views/ZNGPaddedLabel.h
@@ -1,0 +1,15 @@
+//
+//  ZNGPaddedLabel.h
+//  Pods
+//
+//  Created by Jason Neel on 4/19/17.
+//
+//
+
+#import <UIKit/UIKit.h>
+
+@interface ZNGPaddedLabel : UILabel
+
+@property (nonatomic, assign) UIEdgeInsets textInsets;
+
+@end

--- a/Pod/Classes/UI/Views/ZNGPaddedLabel.m
+++ b/Pod/Classes/UI/Views/ZNGPaddedLabel.m
@@ -20,6 +20,10 @@
 
 - (CGRect) textRectForBounds:(CGRect)bounds limitedToNumberOfLines:(NSInteger)numberOfLines
 {
+    if ([self.text length] == 0) {
+        return [super textRectForBounds:bounds limitedToNumberOfLines:numberOfLines];
+    }
+    
     CGRect insetRect = UIEdgeInsetsInsetRect(bounds, self.textInsets);
     CGRect textRect = [super textRectForBounds:insetRect limitedToNumberOfLines:numberOfLines];
     UIEdgeInsets invertedInsets = UIEdgeInsetsMake(-self.textInsets.top, -self.textInsets.left, -self.textInsets.bottom, -self.textInsets.right);
@@ -28,6 +32,10 @@
 
 - (void) drawTextInRect:(CGRect)rect
 {
+    if ([self.text length] == 0) {
+        return [super drawTextInRect:rect];
+    }
+    
     [super drawTextInRect:UIEdgeInsetsInsetRect(rect, self.textInsets)];
 }
 

--- a/Pod/Classes/UI/Views/ZNGPaddedLabel.m
+++ b/Pod/Classes/UI/Views/ZNGPaddedLabel.m
@@ -1,0 +1,34 @@
+//
+//  ZNGPaddedLabel.m
+//  Pods
+//
+//  Created by Jason Neel on 4/19/17.
+//
+//
+
+#import "ZNGPaddedLabel.h"
+
+@implementation ZNGPaddedLabel
+
+- (void) setTextInsets:(UIEdgeInsets)textInsets
+{
+    if (!UIEdgeInsetsEqualToEdgeInsets(textInsets, self.textInsets)) {
+        _textInsets = textInsets;
+        [self invalidateIntrinsicContentSize];
+    }
+}
+
+- (CGRect) textRectForBounds:(CGRect)bounds limitedToNumberOfLines:(NSInteger)numberOfLines
+{
+    CGRect insetRect = UIEdgeInsetsInsetRect(bounds, self.textInsets);
+    CGRect textRect = [super textRectForBounds:insetRect limitedToNumberOfLines:numberOfLines];
+    UIEdgeInsets invertedInsets = UIEdgeInsetsMake(-self.textInsets.top, -self.textInsets.left, -self.textInsets.bottom, -self.textInsets.right);
+    return UIEdgeInsetsInsetRect(textRect, invertedInsets);
+}
+
+- (void) drawTextInRect:(CGRect)rect
+{
+    [super drawTextInRect:UIEdgeInsetsInsetRect(rect, self.textInsets)];
+}
+
+@end


### PR DESCRIPTION
http://jira.zinglecorp.com:8080/browse/IOS-479

- Added some vertical padding for a less scrunched label
- Changed background color to dark blue (instead of puke red and puke orange)
- Changed wording


💬  
&nbsp;&nbsp;&nbsp;&nbsp;🔧  
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;👨‍🎨 