### PR TITLE
IOS-631: Handle an iOS 8 bug that causes text render size to be 0x0

### DIFF
--- a/Pod/Classes/UI/Layout/ZNGBubblesSizeCalculator.m
+++ b/Pod/Classes/UI/Layout/ZNGBubblesSizeCalculator.m
@@ -145,10 +145,18 @@ static const int zngLogLevel = ZNGLogLevelWarning;
         
         CGFloat maximumTextWidth = [self textBubbleWidthForLayout:layout] - avatarSize.width - layout.messageBubbleLeftRightMargin - horizontalInsetsTotal;
         
-        // We have to add 2 to the height for Apple reasons.  Don't ask.  See similar comment below from original JSQMessages code.
-        CGRect stringRect = [string boundingRectWithSize:CGSizeMake(maximumTextWidth, CGFLOAT_MAX) options:(NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading | NSStringDrawingUsesDeviceMetrics) context:nil];
-        stringRect = CGRectMake(stringRect.origin.x, stringRect.origin.y, stringRect.size.width, stringRect.size.height + additionalHeight);
+        BOOL isIOS8OrEarlier = [[[UIDevice currentDevice] systemVersion] compare:@"9.0" options:NSNumericSearch] == NSOrderedAscending;
+        NSStringDrawingOptions stringOptions = (NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading | NSStringDrawingUsesDeviceMetrics);
         
+        if (isIOS8OrEarlier) {
+            // The NSStringDrawingUsesDeviceMetrics flag causes boundingRectWithSize to glitch out and return 0x0 in iOS 8.  Remove that flag.
+            // This will cause us to slightly overestimate bubble sizes in iOS 8.
+            stringOptions = (NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading);
+        }
+
+        // We have to add 2 to the height for Apple reasons.  Don't ask.  See similar comment below from original JSQMessages code.
+        CGRect stringRect = [string boundingRectWithSize:CGSizeMake(maximumTextWidth, CGFLOAT_MAX) options:stringOptions context:nil];
+        stringRect = CGRectMake(stringRect.origin.x, stringRect.origin.y, stringRect.size.width, stringRect.size.height + additionalHeight);
         contentSize = stringRect.size;
     }
     


### PR DESCRIPTION
http://jira.zinglecorp.com:8080/browse/IOS-631

Apparently the NSStringDrawingUsesDeviceMetrics flag for doing string size calculations would return 0 x 0 for certain strings in iOS 8.  This must have been an iOS bug, as the behavior is correct in iOS 9 and iOS 10.

If iOS 8 is detected at run time, we will no longer use that flag, resulting in message bubbles that are occasionally slightly larger than they need to be.

We will probably axe iOS 8 support some time in the near future, but there's no need to do so for this issue.

&nbsp;
&nbsp;

 &nbsp;&nbsp;&nbsp;&nbsp;🅰️
📏   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;🤔 