### PR TITLE
IOS-647: Block user input while a note is outbound

### DIFF
--- a/Pod/Classes/Models/ZNGEvent.h
+++ b/Pod/Classes/Models/ZNGEvent.h
@@ -26,6 +26,12 @@
 @property(nonatomic, strong) ZNGMessage* message;
 
 /**
+ *  Local flag indicating that the event is outbound but has not yet been seen in remote data.
+ *  e.g. The user hit send on a message, but the server has not yet acknowledged it.
+ */
+@property (nonatomic, assign) BOOL sending;
+
+/**
  *  An array of one ZNGEventViewModel in the case of an event with no attachments, up to at most one per attachment plus one text for a non-nil body.
  */
 @property (nonatomic, readonly) NSArray<ZNGEventViewModel *> * viewModels;

--- a/Pod/Classes/Models/ZNGEvent.m
+++ b/Pod/Classes/Models/ZNGEvent.m
@@ -55,6 +55,7 @@ static NSString * const ZNGEventFeedClosed = @"feed_closed";
              @"triggeredByUser" : @"triggered_by_user",
              @"automation" : @"automation",
              @"message" : @"message",
+             NSStringFromSelector(@selector(sending)) : [NSNull null],
              NSStringFromSelector(@selector(viewModels)) : [NSNull null]
              };
 }
@@ -153,6 +154,7 @@ static NSString * const ZNGEventFeedClosed = @"feed_closed";
 {
     ZNGEvent * event = [[ZNGEvent alloc] init];
     event.message = message;
+    event.sending = YES;
     event.eventId = message.messageId;
     event.body = message.body;
     event.eventType = ZNGEventTypeMessage;
@@ -165,6 +167,7 @@ static NSString * const ZNGEventFeedClosed = @"feed_closed";
 {
     ZNGEvent * event = [[ZNGEvent alloc] init];
     event.body = note;
+    event.sending = YES;
     event.eventType = ZNGEventTypeNote;
     event.contactId = contact.contactId;
     event.createdAt = [NSDate date];
@@ -175,7 +178,7 @@ static NSString * const ZNGEventFeedClosed = @"feed_closed";
 
 - (BOOL) isMessage
 {
-    return [self.eventType isEqualToString:ZNGEventTypeMessage] || self.message.sending;
+    return [self.eventType isEqualToString:ZNGEventTypeMessage];
 }
 
 - (BOOL) isNote

--- a/Pod/Classes/Models/ZNGMessage/ZNGMessage.h
+++ b/Pod/Classes/Models/ZNGMessage/ZNGMessage.h
@@ -40,11 +40,6 @@
  */
 @property (nonatomic, readonly) NSString * senderPersonId;
 
-/**
- *  Flag indicating that this message is being sent but does not yet exist on the server
- */
-@property (nonatomic) BOOL sending;
-
 #pragma mark - Properties added by containing Conversation
 @property (nonatomic, copy) NSString * senderDisplayName;
 

--- a/Pod/Classes/Models/ZNGMessage/ZNGMessage.m
+++ b/Pod/Classes/Models/ZNGMessage/ZNGMessage.m
@@ -216,7 +216,6 @@ static const int zngLogLevel = ZNGLogLevelWarning;
              @"attachments" : @"attachments",
              @"createdAt" : @"created_at",
              @"readAt" : @"read_at",
-             @"sending" : [NSNull null],
              NSStringFromSelector(@selector(imageAttachmentsByName)) : [NSNull null],
              NSStringFromSelector(@selector(outgoingImageAttachments)) : [NSNull null]
              };

--- a/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
@@ -1428,7 +1428,7 @@ static void * ZNGConversationKVOContext  =   &ZNGConversationKVOContext;
         JSQMessagesCollectionViewCell * cell = (JSQMessagesCollectionViewCell *)[super collectionView:collectionView cellForItemAtIndexPath:indexPath];
         cell.cellTopLabel.numberOfLines = 0;    // Support multiple lines
         
-        cell.alpha = event.message.sending ? 0.5 : 1.0;
+        cell.alpha = event.sending ? 0.5 : 1.0;
         
         if ([viewModel isMediaMessage]) {
             if ([cell respondsToSelector:@selector(setMediaViewMaskingImage:)]) {

--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -1588,12 +1588,15 @@ static void * KVOContext = &KVOContext;
 {
     __weak ZNGServiceToContactViewController * weakSelf = self;
     
+    self.inputToolbar.inputEnabled = NO;
     [self scrollToBottomAnimated:YES];
     
     [self.conversation addInternalNote:note success:^(ZNGStatus * _Nonnull status) {
+        weakSelf.inputToolbar.inputEnabled = YES;
         [weakSelf scrollToBottomAnimated:YES];
         [[ZNGAnalytics sharedAnalytics] trackAddedNote:note toConversation:weakSelf.conversation];
     } failure:^(ZNGError * _Nonnull error) {
+        weakSelf.inputToolbar.inputEnabled = YES;
         UIAlertController * alert = [UIAlertController alertControllerWithTitle:@"Failed to add note" message:nil preferredStyle:UIAlertControllerStyleAlert];
         UIAlertAction * ok = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
         [alert addAction:ok];

--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -1589,6 +1589,7 @@ static void * KVOContext = &KVOContext;
     __weak ZNGServiceToContactViewController * weakSelf = self;
     
     self.inputToolbar.inputEnabled = NO;
+    self.inputToolbar.sendButton.enabled = NO;
     [self scrollToBottomAnimated:YES];
     
     [self.conversation addInternalNote:note success:^(ZNGStatus * _Nonnull status) {

--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -1233,7 +1233,7 @@ static void * KVOContext = &KVOContext;
         }
         
         // Is it from us?  (current user)
-        if (event.message.sending) {
+        if (event.sending) {
             name = [self.conversation.session.userAuthorization displayName];
             senderUUID = self.conversation.session.userAuthorization.userId;
         } else {

--- a/Pod/Classes/UI/Layout/ZNGBubblesSizeCalculator.m
+++ b/Pod/Classes/UI/Layout/ZNGBubblesSizeCalculator.m
@@ -106,7 +106,7 @@ static const int zngLogLevel = ZNGLogLevelWarning;
     }
     
     // Only attempt to find a cached size if this message is not outgoing from us.  (i.e. do not used cached sizes for outgoing local messages)
-    if (!viewModel.event.message.sending) {
+    if (!viewModel.event.sending) {
         // Cache ID is event ID-itemIndex-number of loaded items.
         // This means that, every time an image is loaded, all sizes for bubbles related to that message will be recalculated.
         cacheID = [NSString stringWithFormat:@"%@-%llu-%llu", viewModel.event.eventId, (unsigned long long)viewModel.index, (unsigned long long)[viewModel.event.message.imageAttachmentsByName count]];

--- a/Pod/Classes/UI/ViewModels/ZNGConversation.h
+++ b/Pod/Classes/UI/ViewModels/ZNGConversation.h
@@ -152,6 +152,11 @@ extern NSString * _Nonnull const ZNGConversationParticipantTypeLabel;
 #pragma mark - Protected methods that can be called by subclasses
 - (void) appendEvents:(nonnull NSArray<ZNGEvent *> *)events;
 
+/**
+ *  Removes any events with sending flags
+ */
+- (void) removeSendingEvents;
+
 #pragma mark - Protected methods to be overridden by subclasses
 
 /**

--- a/Pod/Classes/UI/ViewModels/ZNGConversation.m
+++ b/Pod/Classes/UI/ViewModels/ZNGConversation.m
@@ -472,7 +472,7 @@ static const CGFloat imageAttachmentMaxHeight = 800.0;
     [self markMessagesAsRead:allMessages];
 }
 
-- (void) removeAnyPendingMessages
+- (void) removeSendingEvents
 {
     NSMutableIndexSet * pendingIndexes = [[NSMutableIndexSet alloc] init];
     NSMutableIndexSet * pendingViewModelIndexes = [[NSMutableIndexSet alloc] init];
@@ -666,7 +666,7 @@ static const CGFloat imageAttachmentMaxHeight = 800.0;
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             NSDictionary * params = [self parametersForPageSize:self.pageSize pageIndex:1];
             [self.eventClient eventListWithParameters:params success:^(NSArray<ZNGEvent *> *events, ZNGStatus *status) {
-                [self removeAnyPendingMessages];
+                [self removeSendingEvents];
                 self.totalEventCount = status.totalRecords;
                 
                 // Since we are fetching our data in descending order (so page 1 has recent data,) we need to reverse for proper chronological order
@@ -679,7 +679,7 @@ static const CGFloat imageAttachmentMaxHeight = 800.0;
                     success(status);
                 }
             } failure:^(ZNGError *error) {
-                [self removeAnyPendingMessages];
+                [self removeSendingEvents];
                 ZNGLogError(@"Message send reported success, but we were unable to load event data afterwards.  This is odd.  %@", error);
                 self.loading = NO;
                 
@@ -689,7 +689,7 @@ static const CGFloat imageAttachmentMaxHeight = 800.0;
             }];
         });
     } failure:^(ZNGError *error) {
-        [self removeAnyPendingMessages];
+        [self removeSendingEvents];
         self.loading = NO;
         
         if (failure != nil) {

--- a/Pod/Classes/UI/ViewModels/ZNGConversation.m
+++ b/Pod/Classes/UI/ViewModels/ZNGConversation.m
@@ -478,13 +478,13 @@ static const CGFloat imageAttachmentMaxHeight = 800.0;
     NSMutableIndexSet * pendingViewModelIndexes = [[NSMutableIndexSet alloc] init];
     
     [self.events enumerateObjectsUsingBlock:^(ZNGEvent * _Nonnull event, NSUInteger idx, BOOL * _Nonnull stop) {
-        if (event.message.sending) {
+        if (event.sending) {
             [pendingIndexes addIndex:idx];
         }
     }];
     
     [self.eventViewModels enumerateObjectsUsingBlock:^(ZNGEventViewModel * _Nonnull viewModel, NSUInteger idx, BOOL * _Nonnull stop) {
-        if (viewModel.event.message.sending) {
+        if (viewModel.event.sending) {
             [pendingViewModelIndexes addIndex:idx];
         }
     }];
@@ -604,7 +604,6 @@ static const CGFloat imageAttachmentMaxHeight = 800.0;
     BOOL outbound = [newMessage.recipientType isEqualToString:ZNGConversationParticipantTypeContact];
     
     ZNGMessage * message = [[ZNGMessage alloc] init];
-    message.sending = YES;
     message.body = newMessage.body;
     message.communicationDirection = outbound ? @"outbound" : @"inbound";
     message.senderType = outbound ? @"service" : @"contact";

--- a/Pod/Classes/UI/ViewModels/ZNGConversationServiceToContact.m
+++ b/Pod/Classes/UI/ViewModels/ZNGConversationServiceToContact.m
@@ -166,7 +166,7 @@ static NSString * const ChannelsKVOPath = @"contact.channels";
         } else {
             
             // If this is a pending outgoing message from us, we can shove a "Me" in there.
-            if (message.sending) {
+            if (event.sending) {
                 message.senderDisplayName = @"Me";
                 continue;
             }

--- a/Pod/Classes/UI/ViewModels/ZNGConversationServiceToContact.m
+++ b/Pod/Classes/UI/ViewModels/ZNGConversationServiceToContact.m
@@ -299,10 +299,12 @@ static NSString * const ChannelsKVOPath = @"contact.channels";
     }
     
     ZNGEvent * outgoingNote = [self pendingEventForOutgoingNote:noteString];
+    self.loading = YES;
     
     [self appendEvents:@[outgoingNote]];
     
     [self.eventClient postInternalNote:noteString toContact:self.contact success:^(ZNGEvent *note, ZNGStatus *status) {
+        self.loading = NO;
         [self removeSendingEvents];
         [self addSenderNameToEvents:@[note]];
         [self appendEvents:@[note]];
@@ -312,6 +314,7 @@ static NSString * const ChannelsKVOPath = @"contact.channels";
             success(status);
         }
     } failure:^(ZNGError *error) {
+        self.loading = NO;
         [self removeSendingEvents];
         
         if (failure != nil) {


### PR DESCRIPTION
http://jira.zinglecorp.com:8080/browse/IOS-647

Notes now behave like outgoing messages; the user cannot send replies nor use templates/custom fields while a note is being sent.  The note will also display while sending as messages already do.

:shipit: ✏️  🗒 