### PR TITLE
IOS-648: Avatars on outgoing messages/notes

### DIFF
--- a/Pod/Classes/UI/ViewModels/ZNGConversation.h
+++ b/Pod/Classes/UI/ViewModels/ZNGConversation.h
@@ -167,6 +167,11 @@ extern NSString * _Nonnull const ZNGConversationParticipantTypeLabel;
  */
 - (nullable NSArray<NSString *> *)eventTypes;
 
+/**
+ *  Used to generate an event with a 'sending' flag.  This can be overridden to add user meta data such as avatars.
+ */
+- (nonnull ZNGEvent *)pendingMessageEventForOutgoingMessage:(nonnull ZNGNewMessage *)newMessage;
+
 - (BOOL) pushNotificationRelevantToThisConversation:(nonnull NSNotification *)notification;
 
 - (void) addSenderNameToEvents:(nullable NSArray<ZNGEvent *> *)events;

--- a/Pod/Classes/UI/ViewModels/ZNGConversationServiceToContact.m
+++ b/Pod/Classes/UI/ViewModels/ZNGConversationServiceToContact.m
@@ -15,6 +15,7 @@
 #import "ZNGAnalytics.h"
 #import "ZNGMessageForwardingRequest.h"
 #import "ZNGSocketClient.h"
+#import "ZingleAccountSession.h"
 
 static const int zngLogLevel = ZNGLogLevelWarning;
 
@@ -323,12 +324,25 @@ static NSString * const ChannelsKVOPath = @"contact.channels";
     }];
 }
 
+- (ZNGEvent *)pendingMessageEventForOutgoingMessage:(ZNGNewMessage *)newMessage
+{
+    ZNGEvent * event = [super pendingMessageEventForOutgoingMessage:newMessage];
+    [self addAvatarToSendingEvent:event];
+    return event;
+}
+
 - (ZNGEvent *)pendingEventForOutgoingNote:(NSString *)noteString
 {
     ZNGEvent * event = [ZNGEvent eventForNewNote:noteString toContact:self.contact];
     [self addSenderNameToEvents:@[event]];
+    [self addAvatarToSendingEvent:event];
     [event createViewModels];
     return event;
+}
+
+- (void) addAvatarToSendingEvent:(ZNGEvent *)event
+{
+    event.triggeredByUser = self.session.user;
 }
 
 - (void) triggerAutomation:(ZNGAutomation *)automation completion:(void (^)(BOOL success))completion


### PR DESCRIPTION
http://jira.zinglecorp.com:8080/browse/IOS-648

Do not merge this before https://github.com/Zingle/ios-sdk/pull/40 ❗️ ❗️ 

User meta data will now be attached to the local versions of sending messages/notes, allowing the UI to display avatars.  Previously, the avatar would be the user's initials until the server actually accepted and responded to the message, at which time the avatar would appear.


☁️☁️ ☁️☁️ ☁️☁️ ☁️☁️ ☁️☁️ ☁️☁️ ☁️☁️ ☁️☁️ 
☁️ ☁️☁️ ☁️☁️ ☁️ &nbsp;&nbsp;&nbsp;&nbsp;😲 &nbsp;&nbsp;&nbsp;&nbsp; ☁️ ☁️☁️ ☁️☁️ ☁️☁️ 
☁️ ☁️☁️ ☁️☁️ ☁️☁️ ☁️☁️ ☁️☁️ ☁️☁️ ☁️☁️ ☁️