### PR TITLE
IOS-647: Fixed ghost messages due to stale UUIDs

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGConversationViewController.h
+++ b/Pod/Classes/UI/Controllers/ZNGConversationViewController.h
@@ -157,6 +157,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (ZNGEvent *) priorEventToIndexPath:(NSIndexPath *)indexPath;
 - (ZNGEventViewModel *) priorViewModelToIndexPath:(NSIndexPath *)indexPath;
 - (ZNGEventViewModel *) nextEventViewModelBelowIndexPath:(NSIndexPath *)indexPath;
+- (void) updateUUID;
 
 #pragma mark - Abstract methods that must be overridden by subclasses
 - (BOOL) weAreSendingOutbound;

--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -1615,6 +1615,7 @@ static void * KVOContext = &KVOContext;
 
 - (void) appendStringToMessageInput:(NSString *)text
 {
+    [self updateUUID];
     self.inputToolbar.contentView.textView.text = [self.inputToolbar.contentView.textView.text stringByAppendingString:text];
     [self.inputToolbar toggleSendButtonEnabled];
 }


### PR DESCRIPTION
http://jira.zinglecorp.com:8080/browse/IOS-647

The UUID sent with messages to prevent duplicates was not being reset when inserting a custom field nor a template.  This caused messages that consisted solely of one or the other to be ignored by the server after a note was sent.

Note: The reproduction steps do not work if the user then inserts a single space or edits the template/custom field in any way before hitting send, since this resets the UUID.

👻  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;😨 