### PR TITLE
Inbox data allowing open/closed/both filtering

### DIFF
--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.h
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.h
@@ -7,9 +7,9 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "ZNGInboxDataSet.h"
 
 @class ZNGContactClient;
-@class ZNGInboxDataSet;
 
 @interface ZNGContactDataSetBuilder : NSObject
 
@@ -23,9 +23,9 @@
 @property (nonatomic, strong, nullable) ZNGInboxDataSet * baseDataSet;
 
 /**
- *  Closed or open conversations (can never be both simultaneously)
+ *  Whether to show contacts with open conversations only, closed only, or both.
  */
-@property (nonatomic, assign) BOOL closed;
+@property (nonatomic, assign) ZNGInboxDataSetOpenStatus openStatus;
 
 /**
  *  Show only unconfirmed contacts.  If this is not set, all contacts, both confirmed and unconfirmed, will be included.

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.h
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.h
@@ -38,6 +38,14 @@
 @property (nonatomic, assign) BOOL allowContactsWithNoMessages;
 
 /**
+ *  The fields used to sort contacts.  May include "asc" or "desc" after a space to define order.
+ *  e.g. "last_name asc", "created_at desc"
+ *
+ *  Defaults to ["last_message_created_at desc"]
+ */
+@property (nonatomic, copy, nullable) NSArray<NSString *> * sortFields;
+
+/**
  *  Array of label IDs used to filter contacts.
  */
 @property (nonatomic, copy, nullable) NSArray<NSString *> * labelIds;

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.m
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.m
@@ -20,7 +20,7 @@
 {
     _baseDataSet = baseDataSet;
     
-    self.closed = baseDataSet.closed;
+    self.openStatus = baseDataSet.openStatus;
     self.unconfirmed = baseDataSet.unconfirmed;
     self.labelIds = [baseDataSet.labelIds copy];
     self.groupIds = [baseDataSet.groupIds copy];

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.m
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.m
@@ -27,6 +27,10 @@
     self.searchText = [baseDataSet.searchText copy];
     self.searchMessageBodies = baseDataSet.searchMessageBodies;
     
+    if ([baseDataSet.sortFields count] > 0) {
+        self.sortFields = baseDataSet.sortFields;
+    }
+    
     if (baseDataSet.contactClient != nil) {
         self.contactClient = baseDataSet.contactClient;
     }

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.h
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.h
@@ -103,7 +103,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Convenience constructor that provides a builder object and automatically calls build using it.
  */
-+ (nonnull instancetype) dataSetWithBlock:(void (^ _Nonnull)(ZNGContactDataSetBuilder * builder))builderBlock;
++ (nonnull instancetype) dataSetWithBlock:(__attribute__((noescape)) void (^ _Nonnull)(ZNGContactDataSetBuilder * builder))builderBlock;
 
 - (nonnull instancetype) initWithBuilder:(ZNGContactDataSetBuilder *)builder;
 

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.h
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.h
@@ -17,6 +17,12 @@ typedef enum {
     ZNGInboxDataSetOpenStatusBoth
 } ZNGInboxDataSetOpenStatus;
 
+extern NSString * _Nonnull const ZNGInboxDataSetSortFieldContactCreatedAt;
+extern NSString * _Nonnull const ZNGInboxDataSetSortFieldLastMessageCreatedAt;
+extern NSString * _Nonnull const ZNGInboxDataSetSortFieldLastName;
+extern NSString * _Nonnull const ZNGInboxDataSetSortDirectionAscending;
+extern NSString * _Nonnull const ZNGInboxDataSetSortDirectionDescending;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -80,6 +86,14 @@ NS_ASSUME_NONNULL_BEGIN
  *  If this flag is set, matching contacts will be returned even if there is no message history.
  */
 @property (nonatomic, readonly) BOOL allowContactsWithNoMessages;
+
+/**
+ *  The fields used to sort contacts.  May include "asc" or "desc" after a space to define order.
+ *  e.g. "last_name asc", "created_at desc"
+ *
+ *  Defaults to ["last_message_created_at desc"]
+ */
+@property (nonatomic, readonly, nonnull) NSArray<NSString *> * sortFields;
 
 /**
  *  Array of label IDs used to filter contacts.

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.h
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.h
@@ -11,6 +11,12 @@
 @class ZNGContactClient;
 @class ZNGContactDataSetBuilder;
 
+typedef enum {
+    ZNGInboxDataSetOpenStatusOpen = 0,
+    ZNGInboxDataSetOpenStatusClosed,
+    ZNGInboxDataSetOpenStatusBoth
+} ZNGInboxDataSetOpenStatus;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -61,9 +67,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 
 /**
- *  Closed or open conversations (can never be both simultaneously)
+ *  Whether to show contacts with open conversations only, closed only, or both.
  */
-@property (nonatomic, readonly) BOOL closed;
+@property (nonatomic, readonly) ZNGInboxDataSetOpenStatus openStatus;
 
 /**
  *  Show only unconfirmed contacts.  If this is not set, all contacts, both confirmed and unconfirmed, will be included.

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
@@ -125,7 +125,7 @@ static NSString * const ParameterValueLastMessageCreatedAt = @"last_message_crea
     
     if (self.openStatus == ZNGInboxDataSetOpenStatusOpen) {
         parameters[ParameterKeyIsClosed] = ParameterValueFalse;
-    } else {
+    } else if (self.openStatus == ZNGInboxDataSetOpenStatusClosed) {
         parameters[ParameterKeyIsClosed] = ParameterValueTrue;
     } // else both, so no value for is_closed
     

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
@@ -72,7 +72,7 @@ static NSString * const ParameterValueLastMessageCreatedAt = @"last_message_crea
     if (self != nil) {
         _contactClient = builder.contactClient;
         
-        _closed = builder.closed;
+        _openStatus = builder.openStatus;
         _unconfirmed = builder.unconfirmed;
         _labelIds = builder.labelIds;
         _groupIds = builder.groupIds;
@@ -122,7 +122,11 @@ static NSString * const ParameterValueLastMessageCreatedAt = @"last_message_crea
     parameters[ParameterKeySortField] = ParameterValueLastMessageCreatedAt;
     parameters[ParameterKeySortDirection] = ParameterValueDescending;
     
-    parameters[ParameterKeyIsClosed] = self.closed ? ParameterValueTrue : ParameterValueFalse;
+    if (self.openStatus == ZNGInboxDataSetOpenStatusOpen) {
+        parameters[ParameterKeyIsClosed] = ParameterValueFalse;
+    } else {
+        parameters[ParameterKeyIsClosed] = ParameterValueTrue;
+    } // else both, so no value for is_closed
     
     if (self.unconfirmed) {
         parameters[ParameterKeyIsConfirmed] = ParameterValueFalse;
@@ -522,7 +526,11 @@ static NSString * const ParameterValueLastMessageCreatedAt = @"last_message_crea
 
 - (BOOL) contactBelongsInDataSet:(ZNGContact *)contact
 {
-    if (contact.isClosed != self.closed) {
+    if ((self.openStatus == ZNGInboxDataSetOpenStatusOpen) && (contact.isClosed)) {
+        return NO;
+    }
+    
+    if ((self.openStatus == ZNGInboxDataSetOpenStatusClosed) && (!contact.isClosed)) {
         return NO;
     }
     

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
@@ -18,21 +18,22 @@ static const int zngLogLevel = ZNGLogLevelDebug;
 
 static NSString * const ParameterKeyPageIndex              = @"page";
 static NSString * const ParameterKeyPageSize               = @"page_size";
-static NSString * const ParameterKeySortField              = @"sort_field";
-static NSString * const ParameterKeySortDirection          = @"sort_direction";
+static NSString * const ParameterKeySortFields              = @"sort_fields";
 static NSString * const ParameterKeyLastMessageCreatedAt   = @"last_message_created_at";
 static NSString * const ParameterKeyIsConfirmed            = @"is_confirmed";
 static NSString * const ParameterKeyIsClosed               = @"is_closed";
 static NSString * const ParameterKeyLabelId                = @"label_id";
 static NSString * const ParameterKeyQuery                  = @"query";
 static NSString * const ParameterKeySearchMessageBodies    = @"search_message_bodies";
-
-
 static NSString * const ParameterValueTrue                 = @"true";
 static NSString * const ParameterValueFalse                = @"false";
 static NSString * const ParameterValueGreaterThanZero      = @"greater_than(0)";
-static NSString * const ParameterValueDescending           = @"desc";
-static NSString * const ParameterValueLastMessageCreatedAt = @"last_message_created_at";
+
+NSString * const ZNGInboxDataSetSortFieldContactCreatedAt = @"created_at";
+NSString * const ZNGInboxDataSetSortFieldLastMessageCreatedAt = @"last_message_created_at";
+NSString * const ZNGInboxDataSetSortFieldLastName = @"last_name";
+NSString * const ZNGInboxDataSetSortDirectionAscending = @"asc";
+NSString * const ZNGInboxDataSetSortDirectionDescending = @"desc";
 
 // Readonly property re-declarations to ensure that they are properly backed with KVO compliant setters.
 @interface ZNGInboxDataSet ()
@@ -63,11 +64,22 @@ static NSString * const ParameterValueLastMessageCreatedAt = @"last_message_crea
     return [builder build];
 }
 
+- (nonnull instancetype) init
+{
+    self = [super init];
+    
+    if (self != nil) {
+        _sortFields = @[[NSString stringWithFormat:@"%@ %@", ZNGInboxDataSetSortFieldLastMessageCreatedAt, ZNGInboxDataSetSortDirectionDescending]];
+    }
+    
+    return self;
+}
+
 - (nonnull instancetype) initWithBuilder:(ZNGContactDataSetBuilder *)builder
 {
     NSParameterAssert(builder.contactClient);
     
-    self = [super init];
+    self = [self init];
     
     if (self != nil) {
         _contactClient = builder.contactClient;
@@ -79,6 +91,10 @@ static NSString * const ParameterValueLastMessageCreatedAt = @"last_message_crea
         _groupIds = builder.groupIds;
         _searchText = builder.searchText;
         _searchMessageBodies = builder.searchMessageBodies;
+        
+        if ([builder.sortFields count] > 0) {
+            _sortFields = builder.sortFields;
+        }
         
         fetchQueue = [[NSOperationQueue alloc] init];
         fetchQueue.name = @"Zingle Inbox fetching";
@@ -120,8 +136,8 @@ static NSString * const ParameterValueLastMessageCreatedAt = @"last_message_crea
 {
     NSMutableDictionary * parameters = [[NSMutableDictionary alloc] init];
     parameters[ParameterKeyPageSize] = @(self.pageSize);
-    parameters[ParameterKeySortField] = ParameterValueLastMessageCreatedAt;
-    parameters[ParameterKeySortDirection] = ParameterValueDescending;
+    
+    parameters[ParameterKeySortFields] = self.sortFields;
     
     if (self.openStatus == ZNGInboxDataSetOpenStatusOpen) {
         parameters[ParameterKeyIsClosed] = ParameterValueFalse;

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
@@ -72,6 +72,7 @@ static NSString * const ParameterValueLastMessageCreatedAt = @"last_message_crea
     if (self != nil) {
         _contactClient = builder.contactClient;
         
+        _allowContactsWithNoMessages = builder.allowContactsWithNoMessages;
         _openStatus = builder.openStatus;
         _unconfirmed = builder.unconfirmed;
         _labelIds = builder.labelIds;


### PR DESCRIPTION
- Replaced open/closed boolean with an open/closed/both enumeration.  This will allow the same data set objects to be used to populate contacts tab data (where we do not care if a contact has an open conversation or not.)
- Added a `@noescape` attribute to the builder block to quash circular reference warnings when used in Swift