### PR TITLE
Allow null initials string for initials avatar

### DIFF
--- a/Pod/Classes/UI/Avatars/ZNGInitialsAvatar.h
+++ b/Pod/Classes/UI/Avatars/ZNGInitialsAvatar.h
@@ -16,9 +16,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype) new NS_UNAVAILABLE;
 - (id) init NS_UNAVAILABLE;
 
-- (id) initWithInitials:(NSString *)initials textColor:(UIColor *)textColor backgroundColor:(UIColor *)backgroundColor size:(CGSize)size font:(UIFont *)font;
+- (id) initWithInitials:(nullable NSString *)initials textColor:(UIColor *)textColor backgroundColor:(UIColor *)backgroundColor size:(CGSize)size font:(UIFont *)font;
 
-@property (nonatomic, readonly) NSString * initials;
+@property (nonatomic, readonly, nullable) NSString * initials;
 @property (nonatomic, readonly) UIColor * textColor;
 @property (nonatomic, readonly) UIColor * backgroundColor;
 @property (nonatomic, readonly) CGSize size;

--- a/Pod/Classes/UI/Avatars/ZNGInitialsAvatar.m
+++ b/Pod/Classes/UI/Avatars/ZNGInitialsAvatar.m
@@ -31,14 +31,16 @@
         CGContextSetFillColorWithColor(context, [backgroundColor CGColor]);
         CGContextFillEllipseInRect(context, rect);
         
-        NSDictionary * textAttributes = @{ NSFontAttributeName: font, NSForegroundColorAttributeName : textColor };
-        CGSize initialsSize = [initials sizeWithAttributes:textAttributes];
-        
-        CGFloat heightDifference = rect.size.height - initialsSize.height;
-        CGFloat widthDifference = rect.size.width - initialsSize.width;
-        CGRect initialsRect = CGRectMake(widthDifference * 0.5, heightDifference * 0.5, rect.size.width - widthDifference, rect.size.height - heightDifference);
-        
-        [initials drawInRect:initialsRect withAttributes:textAttributes];
+        if ([initials length] > 0) {
+            NSDictionary * textAttributes = @{ NSFontAttributeName: font, NSForegroundColorAttributeName : textColor };
+            CGSize initialsSize = [initials sizeWithAttributes:textAttributes];
+            
+            CGFloat heightDifference = rect.size.height - initialsSize.height;
+            CGFloat widthDifference = rect.size.width - initialsSize.width;
+            CGRect initialsRect = CGRectMake(widthDifference * 0.5, heightDifference * 0.5, rect.size.width - widthDifference, rect.size.height - heightDifference);
+            
+            [initials drawInRect:initialsRect withAttributes:textAttributes];
+        }
         
         image = UIGraphicsGetImageFromCurrentImageContext();
         UIGraphicsEndImageContext();

--- a/Pod/Classes/UI/Views/ZNGAvatarImageView.h
+++ b/Pod/Classes/UI/Views/ZNGAvatarImageView.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) UIFont * font;
 @property (nonatomic, readonly) UIImage * placeholderImage;
 
-- (id) initWithAvatarUrl:(NSURL * _Nullable)avatarUrl initials:(NSString *)initials size:(CGSize)size backgroundColor:(UIColor * _Nullable)backgroundColor textColor:(UIColor *)textColor font:(UIFont *)font;
+- (id) initWithAvatarUrl:(NSURL * _Nullable)avatarUrl initials:(NSString * _Nullable)initials size:(CGSize)size backgroundColor:(UIColor * _Nullable)backgroundColor textColor:(UIColor *)textColor font:(UIFont *)font;
 
 /**
  *  Can be overridden by subclasses to move the edit icon from its default position of lower right.


### PR DESCRIPTION
A null initials string will render an empty circle for the initials avatar.

⚪️  😕 