### PR TITLE
Added page size to inbox data builder, stopped always searching message bodies

### DIFF
--- a/Example/Tests/TestInboxDataSet.m
+++ b/Example/Tests/TestInboxDataSet.m
@@ -90,8 +90,8 @@
     
     ZNGInboxDataSet * data = [ZNGInboxDataSet dataSetWithBlock:^(ZNGContactDataSetBuilder * _Nonnull builder) {
         builder.contactClient = contactClient;
+        builder.pageSize = pageSize;
     }];
-    data.pageSize = pageSize;
     [data refresh];
     
     NSArray<ZNGContact *> * expectedFirstPage = [hundredsOfDudes subarrayWithRange:NSMakeRange(0, pageSize)];
@@ -136,8 +136,8 @@
     contactClient.contacts = oneHundredDudes;
     ZNGInboxDataSet * data = [ZNGInboxDataSet dataSetWithBlock:^(ZNGContactDataSetBuilder * _Nonnull builder) {
         builder.contactClient = contactClient;
+        builder.pageSize = pageSize;
     }];
-    data.pageSize = pageSize;
     [data refresh];
     
     // Ensure he is indeed unconfirmed
@@ -196,8 +196,8 @@
     ZNGInboxDataSet * data = [ZNGInboxDataSet dataSetWithBlock:^(ZNGContactDataSetBuilder * _Nonnull builder) {
         builder.contactClient = contactClient;
         builder.unconfirmed = YES;
+        builder.pageSize = pageSize;
     }];
-    data.pageSize = pageSize;
     [data refresh];
 
     
@@ -250,8 +250,8 @@
     ZNGInboxDataSet * data = [ZNGInboxDataSet dataSetWithBlock:^(ZNGContactDataSetBuilder * _Nonnull builder) {
         builder.contactClient = contactClient;
         builder.unconfirmed = YES;
+        builder.pageSize = pageSize;
     }];
-    data.pageSize = pageSize;
     [data refresh];
     
     
@@ -309,8 +309,8 @@
     contactClient.contacts = twoDudes;
     ZNGInboxDataSet * data = [ZNGInboxDataSet dataSetWithBlock:^(ZNGContactDataSetBuilder * _Nonnull builder) {
         builder.contactClient = contactClient;
+        builder.pageSize = pageSize;
     }];
-    data.pageSize = pageSize;
     [data refresh];
     
     

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.h
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.h
@@ -23,6 +23,11 @@
 @property (nonatomic, strong, nullable) ZNGInboxDataSet * baseDataSet;
 
 /**
+ *  How many contacts to load in each query.  Defaults to 25.
+ */
+@property (nonatomic, assign) NSUInteger pageSize;
+
+/**
  *  Whether to show contacts with open conversations only, closed only, or both.
  */
 @property (nonatomic, assign) ZNGInboxDataSetOpenStatus openStatus;

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.m
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.m
@@ -20,6 +20,7 @@
 {
     _baseDataSet = baseDataSet;
     
+    self.pageSize = baseDataSet.pageSize;
     self.openStatus = baseDataSet.openStatus;
     self.unconfirmed = baseDataSet.unconfirmed;
     self.labelIds = [baseDataSet.labelIds copy];

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.h
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.h
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Page size!
  */
-@property (nonatomic, assign) NSUInteger pageSize;
+@property (nonatomic, readonly) NSUInteger pageSize;
 
 /**
  *  A human-readable title for the current filter set.

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
@@ -172,7 +172,10 @@ NSString * const ZNGInboxDataSetSortDirectionDescending = @"desc";
     }
     
     if ([self.searchText length] > 0) {
-        parameters[ParameterKeySearchMessageBodies] = self.searchMessageBodies ? ParameterValueTrue : ParameterValueFalse;
+        if (self.searchMessageBodies) {
+           parameters[ParameterKeySearchMessageBodies] = ParameterValueTrue;
+        }
+        
         parameters[ParameterKeyQuery] = [self.searchText copy];
     }
 

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
@@ -84,6 +84,7 @@ NSString * const ZNGInboxDataSetSortDirectionDescending = @"desc";
     if (self != nil) {
         _contactClient = builder.contactClient;
         
+        _pageSize = builder.pageSize;
         _allowContactsWithNoMessages = builder.allowContactsWithNoMessages;
         _openStatus = builder.openStatus;
         _unconfirmed = builder.unconfirmed;
@@ -96,12 +97,15 @@ NSString * const ZNGInboxDataSetSortDirectionDescending = @"desc";
             _sortFields = builder.sortFields;
         }
         
+        if (_pageSize == 0) {
+            _pageSize = 25;
+        }
+        
         fetchQueue = [[NSOperationQueue alloc] init];
         fetchQueue.name = @"Zingle Inbox fetching";
         fetchQueue.maxConcurrentOperationCount = 1;
         
         _contacts = [[NSOrderedSet alloc] init];
-        _pageSize = 25;
         
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(refreshDueToPushNotification:) name:ZNGPushNotificationReceived object:nil];
     }


### PR DESCRIPTION
- Moved page size to immutable, readonly property set via builder
- Stopped sending 'false' for search_message_bodies, because the API interprets 'false' as HE SAID SOMETHING SO HE MUST WANT IT.

💢 