### PR TITLE
Fixed an incorrect cell type crash

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
@@ -183,6 +183,11 @@ static void * ZNGConversationKVOContext  =   &ZNGConversationKVOContext;
 {
     [super viewDidLoad];
     
+    self.outgoingCellIdentifier = [ZNGConversationCellOutgoing cellReuseIdentifier];
+    self.incomingCellIdentifier = [ZNGConversationCellIncoming cellReuseIdentifier];
+    self.outgoingMediaCellIdentifier = [ZNGConversationCellOutgoing mediaCellReuseIdentifier];
+    self.incomingMediaCellIdentifier = [ZNGConversationCellIncoming mediaCellReuseIdentifier];
+    
     [self setupLoadingGradient];
     
     [self updateUUID];
@@ -196,11 +201,6 @@ static void * ZNGConversationKVOContext  =   &ZNGConversationKVOContext;
     self.inputToolbar.contentView.textView.font = self.textInputFont;
     self.inputToolbar.sendButtonColor = self.sendButtonColor;
     self.inputToolbar.sendButtonFont = self.sendButtonFont;
-    
-    self.outgoingCellIdentifier = [ZNGConversationCellOutgoing cellReuseIdentifier];
-    self.incomingCellIdentifier = [ZNGConversationCellIncoming cellReuseIdentifier];
-    self.outgoingMediaCellIdentifier = [ZNGConversationCellOutgoing mediaCellReuseIdentifier];
-    self.incomingMediaCellIdentifier = [ZNGConversationCellIncoming mediaCellReuseIdentifier];
     
     self.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Back" style:UIBarButtonItemStylePlain target:nil action:nil];
     self.collectionView.collectionViewLayout.incomingAvatarViewSize = CGSizeZero;


### PR DESCRIPTION
This had been seen once or twice (never in the wild.)  Some upcoming changes to add skeleton loading views made this crash easily reproducible.  Sometimes the view hierarchy could be loaded while the values for message cell identifier were still set to the original, superclass value.  Moving the setting of these values up in the load process solved the problem.

⬆️ ⬆️ ⬆️ ⬆️ ⬆️ ⬆️ ⬆️ ⬆️  🆙  ⬆️ ⬆️ ⬆️ ⬆️ ⬆️ ⬆️ ⬆️ ⬆️ ⬆️ 
https://youtu.be/ufw9dVys3t0