### PR TITLE
IOS-649: Smarter image displaying

### DIFF
--- a/Pod/Classes/Models/ZNGMessage/ZNGMessage.h
+++ b/Pod/Classes/Models/ZNGMessage/ZNGMessage.h
@@ -11,9 +11,6 @@
 #import "ZNGUser.h"
 #import <JSQMessagesViewController/JSQMessageData.h>
 
-// Posted through NSNotificationCenter when media has finished downloading
-#define kZNGMessageMediaLoadedNotification  @"kZNGMessageMediaLoadedNotification"
-
 @interface ZNGMessage : MTLModel<MTLJSONSerializing, JSQMessageData>
 
 #pragma mark - JSON properties
@@ -44,11 +41,6 @@
 @property (nonatomic, copy) NSString * senderDisplayName;
 
 /**
- *  KVO compliant dictionary that will be loaded with image data from attachments
- */
-@property (nonatomic, strong) NSMutableDictionary<NSString *, UIImage *> * imageAttachmentsByName;
-
-/**
  *  Used only for transient outgoing message data objects.  This entire ZNGMessage object will be replaced once the server acknowledges the outbound message.
  */
 @property (nonatomic, strong) NSArray<UIImage *> * outgoingImageAttachments;
@@ -59,8 +51,6 @@
 - (NSString *) triggeredByUserIdOrSenderId;
 
 - (BOOL) isOutbound;
-
-- (void) downloadAttachmentsIfNecessary;
 
 /**
  *  The sender or receiver, whichever corresponds to a contact.

--- a/Pod/Classes/Models/ZNGMessage/ZNGMessage.m
+++ b/Pod/Classes/Models/ZNGMessage/ZNGMessage.m
@@ -7,7 +7,6 @@
 //
 
 #import "ZNGMessage.h"
-#import "ZNGLogging.h"
 #import "ZingleValueTransformers.h"
 #import "JSQPhotoMediaItem.h"
 #import "JSQMessagesMediaPlaceholderView.h"
@@ -17,8 +16,6 @@
 #import "ZNGPlaceholderImageAttachment.h"
 #import <ImageIO/ImageIO.h>
 #import "UIImage+animatedGIF.h"
-
-static const int zngLogLevel = ZNGLogLevelWarning;
 
 @implementation ZNGMessage
 {

--- a/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
@@ -1437,14 +1437,16 @@ static void * ZNGConversationKVOContext  =   &ZNGConversationKVOContext;
 {
     // Is there an image here?
     ZNGEventViewModel * viewModel = [self eventViewModelAtIndexPath:indexPath];
-    UIImage * image = viewModel.event.message.imageAttachmentsByName[viewModel.attachmentName];
+    NSString * attachmentName = [viewModel attachmentName];
     
-    if (image == nil) {
+    if ([attachmentName length] == 0) {
         return;
     }
     
+    NSURL * attachmentURL = [NSURL URLWithString:attachmentName];
+    
     ZNGImageViewController * imageView = [[ZNGImageViewController alloc] init];
-    imageView.image = image;
+    imageView.imageURL = attachmentURL;
     imageView.navigationItem.title = self.navigationItem.title;
     
     // Prevent JSQMessagesViewController from being an absolute ass and scrolling to the bottom when we come back.

--- a/Pod/Classes/UI/Controllers/ZNGImageViewController.h
+++ b/Pod/Classes/UI/Controllers/ZNGImageViewController.h
@@ -8,9 +8,11 @@
 
 #import <UIKit/UIKit.h>
 
+@class FLAnimatedImageView;
+
 @interface ZNGImageViewController : UIViewController
 
-@property (nonatomic, strong) IBOutlet UIImageView * imageView;
-@property (nonatomic, strong) UIImage * image;
+@property (nonatomic, strong) IBOutlet FLAnimatedImageView * imageView;
+@property (nonatomic, copy) NSURL * imageURL;
 
 @end

--- a/Pod/Classes/UI/Controllers/ZNGImageViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGImageViewController.m
@@ -8,6 +8,9 @@
 
 #import "ZNGImageViewController.h"
 
+@import FLAnimatedImage;
+@import SDWebImage;
+
 @interface ZNGImageViewController ()
 
 @end
@@ -16,27 +19,35 @@
 
 - (id) init
 {
-    return [super initWithNibName:NSStringFromClass([self class]) bundle:[NSBundle bundleForClass:[self class]]];
+    return [super initWithNibName:NSStringFromClass([ZNGImageViewController class]) bundle:[NSBundle bundleForClass:[ZNGImageViewController class]]];
 }
 
-- (void)viewDidLoad {
+- (void)viewDidLoad
+{
     [super viewDidLoad];
     
-    self.imageView.image = self.image;
+    [self.imageView sd_setImageWithURL:self.imageURL placeholderImage:nil];
     
     UIBarButtonItem * shareButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction target:self action:@selector(pressedShare:)];
     self.navigationItem.rightBarButtonItem = shareButton;
 }
 
-- (void) setImage:(UIImage *)image
+- (void) setImageURL:(NSURL *)imageURL
 {
-    _image = image;
-    self.imageView.image = image;
+    _imageURL = [imageURL copy];
+    [self.imageView sd_setImageWithURL:_imageURL placeholderImage:nil];
 }
                                      
 - (void) pressedShare:(id)sender
 {
-    UIActivityViewController * shareView = [[UIActivityViewController alloc] initWithActivityItems:@[self.image] applicationActivities:nil];
+    UIImage * image = self.imageView.image;
+    
+    if (image == nil)
+    {
+        return;
+    }
+    
+    UIActivityViewController * shareView = [[UIActivityViewController alloc] initWithActivityItems:@[image] applicationActivities:nil];
     shareView.popoverPresentationController.barButtonItem = self.navigationItem.rightBarButtonItem;
     [self presentViewController:shareView animated:YES completion:nil];
 }

--- a/Pod/Classes/UI/Controllers/ZNGImageViewController.xib
+++ b/Pod/Classes/UI/Controllers/ZNGImageViewController.xib
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ZNGImageViewController">
@@ -13,14 +17,14 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="F7C-QT-JqW">
-                    <rect key="frame" x="0.0" y="61" width="600" height="539"/>
+                <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="F7C-QT-JqW" customClass="FLAnimatedImageView">
+                    <rect key="frame" x="0.0" y="61" width="375" height="606"/>
                 </imageView>
             </subviews>
-            <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="F7C-QT-JqW" secondAttribute="bottom" id="2hJ-rC-Ah4"/>
                 <constraint firstAttribute="trailing" secondItem="F7C-QT-JqW" secondAttribute="trailing" id="GLP-K2-Kv0"/>

--- a/Pod/Classes/UI/Layout/ZNGBubblesSizeCalculator.m
+++ b/Pod/Classes/UI/Layout/ZNGBubblesSizeCalculator.m
@@ -107,9 +107,8 @@ static const int zngLogLevel = ZNGLogLevelWarning;
     
     // Only attempt to find a cached size if this message is not outgoing from us.  (i.e. do not used cached sizes for outgoing local messages)
     if (!viewModel.event.sending) {
-        // Cache ID is event ID-itemIndex-number of loaded items.
-        // This means that, every time an image is loaded, all sizes for bubbles related to that message will be recalculated.
-        cacheID = [NSString stringWithFormat:@"%@-%llu-%llu", viewModel.event.eventId, (unsigned long long)viewModel.index, (unsigned long long)[viewModel.event.message.imageAttachmentsByName count]];
+        // Cache ID is event ID-itemIndex-flag for whether image size is exact
+        cacheID = [NSString stringWithFormat:@"%@-%llu-%d", viewModel.event.eventId, (unsigned long long)viewModel.index, (int)viewModel.exactImageSizeCalculated];
         NSValue * cachedSize = [cache objectForKey:cacheID];
         
         if (cachedSize != nil) {

--- a/Pod/Classes/UI/Layout/ZNGImageSizeCache.m
+++ b/Pod/Classes/UI/Layout/ZNGImageSizeCache.m
@@ -49,8 +49,6 @@ static const int zngLogLevel = ZNGLogLevelWarning;
         NSString * cacheFolder = [paths firstObject];
         cacheFilePath = [cacheFolder stringByAppendingPathComponent:kCacheFileName];
         
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(imageDownloaded:) name:kZNGMessageMediaLoadedNotification object:nil];
-        
         loading = YES;
         [self loadCachedSizes];
     }
@@ -89,28 +87,6 @@ static const int zngLogLevel = ZNGLogLevelWarning;
         ZNGLogInfo(@"Writing %llu cached sizes to %@", (unsigned long long)[sizes count], cacheFilePath);
         [NSKeyedArchiver archiveRootObject:sizes toFile:cacheFilePath];
     });
-}
-
-- (void) imageDownloaded:(NSNotification *)notification
-{
-    ZNGMessage * message = notification.object;
-    
-    if (![message isKindOfClass:[ZNGMessage class]]) {
-        NSAssert(NO, @"Notification for downloaded image attachment was from a %@ instead of a ZNGMessage.  What?", [message class]);
-    }
-    
-    __block NSUInteger count = 0;
-    
-    [message.imageAttachmentsByName enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull filename, UIImage * _Nonnull image, BOOL * _Nonnull stop) {
-        if ((filename != nil) && (image != nil)) {
-            [self setSize:image.size forImageWithPath:filename save:NO];
-            count++;
-        }
-    }];
-    
-    if (count > 0) {
-        [self saveCachedSizes];
-    }
 }
 
 - (CGSize) sizeForImageWithPath:(NSString *)filename

--- a/Pod/Classes/UI/Layout/ZNGImageSizeCache.m
+++ b/Pod/Classes/UI/Layout/ZNGImageSizeCache.m
@@ -97,6 +97,10 @@ static const int zngLogLevel = ZNGLogLevelWarning;
         return CGSizeZero;
     }
     
+    if ([filename isKindOfClass:[NSNull class]]) {
+        return CGSizeZero;
+    }
+    
     NSString * name = [filename lastPathComponent];
     CGSize size = [sizes[name] CGSizeValue];
     

--- a/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.h
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.h
@@ -13,6 +13,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ *  An NSNotification will be posted to the shared NSNotificationCenter with this name and the ZNGEventViewModel as its object if
+ *   the image size corresponding to this event view model has changed (i.e. it was not loaded/cached, and now we know how big it is.)
+ */
+extern NSString * const ZNGEventViewModelImageSizeChangedNotification;
+
 @class ZNGEvent;
 
 @interface ZNGEventViewModel : NSObject <JSQMessageData, JSQMessageMediaData>

--- a/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.h
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.h
@@ -29,6 +29,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readonly) NSString * attachmentName;
 
+/**
+ *  Flag that is set if we are confidence that our mediaViewDisplaySize is accurate and not an estimate.
+ */
+@property (nonatomic, readonly) BOOL exactImageSizeCalculated;
+
 - (id) initWithEvent:(ZNGEvent *)event index:(NSUInteger)index;
 
 @end

--- a/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.m
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.m
@@ -48,6 +48,10 @@ static const int zngLogLevel = ZNGLogLevelWarning;
 
 - (BOOL) exactImageSizeCalculated
 {
+    if (self.attachmentName == nil) {
+        return NO;
+    }
+    
     return !CGSizeEqualToSize([[ZNGImageSizeCache sharedCache] sizeForImageWithPath:[self attachmentName]], CGSizeZero);
 }
 

--- a/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.m
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.m
@@ -46,6 +46,11 @@ static const int zngLogLevel = ZNGLogLevelWarning;
     return ((self.index == object.index) && ([self.event.eventId isEqualToString:object.event.eventId]));
 }
 
+- (BOOL) exactImageSizeCalculated
+{
+    return !CGSizeEqualToSize([[ZNGImageSizeCache sharedCache] sizeForImageWithPath:[self attachmentName]], CGSizeZero);
+}
+
 // Our text body will always be the last entry
 - (NSUInteger) textIndex
 {

--- a/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.m
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.m
@@ -148,6 +148,8 @@ static const int zngLogLevel = ZNGLogLevelWarning;
     NSURL * attachmentURL = [NSURL URLWithString:[self attachmentName]];
     
     FLAnimatedImageView * animatedImageView = [[FLAnimatedImageView alloc] init];
+    animatedImageView.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.05];
+    animatedImageView.tintColor = [UIColor colorWithWhite:0.0 alpha:0.15];
     imageView = animatedImageView;
     
     // Set content mode to center so our placeholder image is centered instead of stretched.  Content mode will be reset when the image loads.

--- a/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.m
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.m
@@ -126,20 +126,17 @@ static const int zngLogLevel = ZNGLogLevelWarning;
 
 - (UIView *)mediaView
 {
+    // If this is an outgoing image, we will return a UIImageView containing it.
+    if ([self.event.message.outgoingImageAttachments count] > self.index) {
+        UIImage * image = self.event.message.outgoingImageAttachments[self.index];
+        return [[UIImageView alloc] initWithImage:image];
+    }
+    
     if (([[self attachmentName] length] == 0) && ([self.event.message.outgoingImageAttachments count] == 0)) {
         return nil;
     }
     
-    if (imageView != nil) {
-        return imageView;
-    }
-    
-    // If this is an outgoing image, we will return a normal UIImageView containing it.
-    if ([self.event.message.outgoingImageAttachments count] > self.index) {
-        UIImage * image = self.event.message.outgoingImageAttachments[self.index];
-        imageView = [[UIImageView alloc] initWithImage:image];
-        return imageView;
-    }
+    CGSize previouslyKnownImageSize = [self mediaViewDisplaySize];
     
     // This is a normal image attachment.  We will set its URL via SDWebImage and plop a placeholder in place.
     NSBundle * bundle = [NSBundle bundleForClass:[ZNGEventViewModel class]];
@@ -176,7 +173,15 @@ static const int zngLogLevel = ZNGLogLevelWarning;
  */
 - (CGSize)mediaViewDisplaySize
 {
-    CGSize size = [[ZNGImageSizeCache sharedCache] sizeForImageWithPath:[self attachmentName]];
+    CGSize size;
+    
+    if ([self.event.message.outgoingImageAttachments count] > self.index) {
+        // This is an outgoing image attachment
+        UIImage * image = self.event.message.outgoingImageAttachments[self.index];
+        size = image.size;
+    } else {
+        size = [[ZNGImageSizeCache sharedCache] sizeForImageWithPath:[self attachmentName]];
+    }
     
     if ((size.height == 0.0) || (size.width == 0.0)) {
         size = [self maximumImageDisplaySize];

--- a/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.m
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.m
@@ -16,9 +16,6 @@
 static const int zngLogLevel = ZNGLogLevelWarning;
 
 @implementation ZNGEventViewModel
-{
-    UIImageView * imageView;
-}
 
 - (id) initWithEvent:(ZNGEvent *)event index:(NSUInteger)index
 {
@@ -147,7 +144,6 @@ static const int zngLogLevel = ZNGLogLevelWarning;
     FLAnimatedImageView * animatedImageView = [[FLAnimatedImageView alloc] init];
     animatedImageView.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.05];
     animatedImageView.tintColor = [UIColor colorWithWhite:0.0 alpha:0.15];
-    imageView = animatedImageView;
     
     // Set content mode to center so our placeholder image is centered instead of stretched.  Content mode will be reset when the image loads.
     animatedImageView.contentMode = UIViewContentModeCenter;

--- a/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.m
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.m
@@ -15,6 +15,8 @@
 
 static const int zngLogLevel = ZNGLogLevelWarning;
 
+NSString * const ZNGEventViewModelImageSizeChangedNotification = @"ZNGEventViewModelImageSizeChangedNotification";
+
 @implementation ZNGEventViewModel
 
 - (id) initWithEvent:(ZNGEvent *)event index:(NSUInteger)index
@@ -154,8 +156,13 @@ static const int zngLogLevel = ZNGLogLevelWarning;
             // Set the content mode back to fill
             animatedImageView.contentMode = UIViewContentModeScaleAspectFill;
             
-            // Save the image size to cache
-            [[ZNGImageSizeCache sharedCache] setSize:image.size forImageWithPath:[self attachmentName]];
+            // If this size is new, post a notification
+            if ((cacheType == SDImageCacheTypeNone) && (!CGSizeEqualToSize(previouslyKnownImageSize, image.size))) {
+                // Save the image size to cache
+                [[ZNGImageSizeCache sharedCache] setSize:image.size forImageWithPath:[self attachmentName]];
+                
+                [[NSNotificationCenter defaultCenter] postNotificationName:ZNGEventViewModelImageSizeChangedNotification object:self];
+            }
         }
     }];
     

--- a/ZingleSDK.podspec
+++ b/ZingleSDK.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
   s.dependency 'JSQMessagesViewController'
   s.dependency 'Analytics', '~> 3.0'
   s.dependency 'MGSwipeTableCell'
-  s.dependency 'SDWebImage'
+  s.dependency 'SDWebImage/GIF'
   s.dependency 'Socket.IO-Client-Swift'
   s.dependency 'Shimmer'
 end


### PR DESCRIPTION
http://jira.zinglecorp.com:8080/browse/IOS-649

Changed from stupidly downloading every image attachment in order as soon as it appeared in data and not really caching anything to using the SDWebImage library to display images on demand with caching.

💁‍♂️ 📷  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;↔️ &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 💾 