### PR TITLE
Contact search fix for contacts with no messages

### DIFF
--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.m
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.m
@@ -27,6 +27,7 @@
     self.groupIds = [baseDataSet.groupIds copy];
     self.searchText = [baseDataSet.searchText copy];
     self.searchMessageBodies = baseDataSet.searchMessageBodies;
+    self.allowContactsWithNoMessages = baseDataSet.allowContactsWithNoMessages;
     
     if ([baseDataSet.sortFields count] > 0) {
         self.sortFields = baseDataSet.sortFields;


### PR DESCRIPTION
Contacts with no message history were showing up in the total contacts list, but they were not showing up when a search term was typed.  This was due to a bug in the contact data set builder copying code.

![Machine](http://i.imgur.com/BWU2W6V.gif)