### PR TITLE
IOS-676: Hiding text input cursor if user presses input buttons

### DIFF
--- a/Pod/Classes/UI/Views/ZNGConversationTextView.h
+++ b/Pod/Classes/UI/Views/ZNGConversationTextView.h
@@ -10,4 +10,6 @@
 
 @interface ZNGConversationTextView : JSQMessagesComposerTextView
 
+@property (nonatomic, assign) BOOL hideCursor;
+
 @end

--- a/Pod/Classes/UI/Views/ZNGConversationTextView.m
+++ b/Pod/Classes/UI/Views/ZNGConversationTextView.m
@@ -61,6 +61,21 @@ static const int zngLogLevel = ZNGLogLevelWarning;
     }
 }
 
+- (void) setHideCursor:(BOOL)hideCursor
+{
+    _hideCursor = hideCursor;
+    [self setNeedsDisplay];
+}
+
+- (CGRect) caretRectForPosition:(UITextPosition *)position
+{
+    if (self.hideCursor) {
+        return CGRectZero;
+    }
+    
+    return [super caretRectForPosition:position];
+}
+
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
 {
     if (!self.editable) {

--- a/Pod/Classes/UI/Views/ZNGConversationToolbarContentView.h
+++ b/Pod/Classes/UI/Views/ZNGConversationToolbarContentView.h
@@ -7,6 +7,7 @@
 //
 
 #import <JSQMessagesViewController/JSQMessagesViewController.h>
+#import "ZNGConversationTextView.h"
 
 @interface ZNGConversationToolbarContentView : JSQMessagesToolbarContentView
 
@@ -17,6 +18,8 @@
 @property (nonatomic, strong, nullable) IBOutlet UIButton * noteButton;
 @property (nonatomic, strong, nullable) IBOutlet UIButton * revealButton;
 @property (nonatomic, strong, nullable) IBOutlet UIButton * channelSelectButton;
+
+@property (weak, nonatomic, readonly, nullable) ZNGConversationTextView * textView;
 
 - (void) collapseButtons:(BOOL)animated;
 - (void) expandButtons:(BOOL)animated;

--- a/Pod/Classes/UI/Views/ZNGConversationToolbarContentView.m
+++ b/Pod/Classes/UI/Views/ZNGConversationToolbarContentView.m
@@ -12,6 +12,8 @@
 
 @implementation ZNGConversationToolbarContentView
 
+@dynamic textView;
+
 - (void) awakeFromNib
 {
     [super awakeFromNib];

--- a/Pod/Classes/UI/Views/ZNGServiceConversationInputToolbar.h
+++ b/Pod/Classes/UI/Views/ZNGServiceConversationInputToolbar.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface ZNGServiceConversationInputToolbar : ZNGConversationInputToolbar
+@interface ZNGServiceConversationInputToolbar : ZNGConversationInputToolbar <UIGestureRecognizerDelegate>
 
 @property (weak, nonatomic, nullable) id<ZNGServiceConversationInputToolbarDelegate> delegate;
 

--- a/Pod/Classes/UI/Views/ZNGServiceConversationInputToolbar.m
+++ b/Pod/Classes/UI/Views/ZNGServiceConversationInputToolbar.m
@@ -14,6 +14,9 @@
 #import "ZNGLogging.h"
 
 @implementation ZNGServiceConversationInputToolbar
+{
+    UIColor * originalTextViewTintColor;
+}
 
 @dynamic contentView;
 @dynamic delegate;
@@ -40,6 +43,14 @@
     self.contentView.rightBarButtonItemWidth = sendButtonSize.width;
     
     self.currentChannel = nil;
+    
+    originalTextViewTintColor = self.contentView.textView.tintColor;
+    
+    UITapGestureRecognizer * tapper = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(userTappedTextView:)];
+    tapper.cancelsTouchesInView = NO;
+    tapper.delaysTouchesEnded = NO;
+    tapper.delegate = self;
+    [self.contentView.textView addGestureRecognizer:tapper];
 }
 
 - (JSQMessagesToolbarContentView *)loadToolbarContentView
@@ -151,11 +162,23 @@
 
 - (IBAction)didPressRevealButton:(id)sender
 {
+    self.contentView.textView.hideCursor = YES;
     [self.contentView expandButtons:YES];
+}
+
+- (BOOL) gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+    return YES;
+}
+
+- (void) userTappedTextView:(UITapGestureRecognizer *)tapper
+{
+    [self collapseInputButtons];
 }
 
 - (void) collapseInputButtons
 {
+    self.contentView.textView.hideCursor = NO;
     [self.contentView collapseButtons:YES];
 }
 


### PR DESCRIPTION
:warning: https://github.com/Zingle/ios-business-app/pull/67 should be merged before this PR. :warning:

http://jira.zinglecorp.com:8080/browse/IOS-676

Added a hideCursor property to text view subclass.  Use it if the user expands input buttons and if they return via touch or text input.

🥇 