### PR TITLE
IOS-678: Canceling internal note no longer returns input to text field

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -1526,6 +1526,7 @@ static void * KVOContext = &KVOContext;
     [alert addAction:addNote];
     [alert addAction:cancel];
     
+    [self.inputToolbar.contentView.textView resignFirstResponder];
     [self presentViewController:alert animated:YES completion:nil];
 }
 


### PR DESCRIPTION
http://jira.zinglecorp.com:8080/browse/IOS-678

✏️ 