### PR TITLE
IOS-688: Added top level sort direction to event queries to allow tie breaking

### DIFF
--- a/Pod/Classes/UI/ViewModels/Events/ZNGConversation.m
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGConversation.m
@@ -425,6 +425,7 @@ static const CGFloat imageAttachmentMaxHeight = 800.0;
                                      kConversationContactId : contactId,
                                      kConversationPage: @(pageIndex),
                                      kConversationSortFields : @[isDelayedSort, executeAtSort, updatedAtSort, idSort],
+                                     kConversationSortDirection: kConversationSortDirectionDescending,
                                      } mutableCopy];
     
     if ([eventTypes count] > 0) {


### PR DESCRIPTION
http://jira.zinglecorp.com:8080/browse/IOS-688

Events that happen simultaneously now appear in a more sane order.  (Example: Incoming message, keyword automation started, reply send, keyword automation ended)

![numbers](http://i.imgur.com/pKAW2A5.jpg)