### PR TITLE
Added push environment specification to push registrations

### DIFF
--- a/Pod/Classes/Clients/ZNGNotificationsClient.m
+++ b/Pod/Classes/Clients/ZNGNotificationsClient.m
@@ -23,6 +23,10 @@
     registration.serviceIds = serviceIds;
     registration.operatingSystem = @"ios";
     
+#if DEBUG
+    registration.pushEnvironment = @"dev";
+#endif
+    
     NSString *path = @"receive-notifications";
     
     [self postWithModel:registration

--- a/Pod/Classes/Models/ZNGNotificationRegistration.h
+++ b/Pod/Classes/Models/ZNGNotificationRegistration.h
@@ -10,8 +10,15 @@
 
 @interface ZNGNotificationRegistration : MTLModel<MTLJSONSerializing>
 
-@property (nonatomic, strong) NSString *deviceIdentifier;
-@property (nonatomic, strong) NSArray *serviceIds;
-@property (nonatomic, strong) NSString *operatingSystem;
+@property (nonatomic, strong, nullable) NSString *deviceIdentifier;
+@property (nonatomic, strong, nullable) NSArray *serviceIds;
+@property (nonatomic, strong, nullable) NSString *operatingSystem;
+
+/**
+ *  Optional string specifying "dev" or "production"
+ *
+ *  This will determine which APNS certificate the server will attempt to use.
+ */
+@property (nonatomic, copy, nullable) NSString * pushEnvironment;
 
 @end

--- a/Pod/Classes/Models/ZNGNotificationRegistration.m
+++ b/Pod/Classes/Models/ZNGNotificationRegistration.m
@@ -15,7 +15,8 @@
     return @{
              @"deviceIdentifier" : @"device_identifier",
              @"serviceIds" : @"service_ids",
-             @"operatingSystem" : @"operating_system"
+             @"operatingSystem" : @"operating_system",
+             NSStringFromSelector(@selector(pushEnvironment)): @"push_environment"
              };
 }
 


### PR DESCRIPTION
Devices can now specify either dev (sandbox) or production push certificates be used when pushing data to them.  This choice is based on whether the app itself was signed with a development or production distribution certificate.  We'll check for a `DEBUG` preprocessor value on compile and choose from there.

![disguise](http://i.imgur.com/kgcVzdE.png)