### PR TITLE
IOS-693: Typing indicator changes

### DIFF
--- a/Pod/Classes/Clients/ZNGSocketClient.m
+++ b/Pod/Classes/Clients/ZNGSocketClient.m
@@ -163,6 +163,10 @@ static const int zngLogLevel = ZNGLogLevelWarning;
         [weakSelf socketDidBindNodeController];
     }];
     
+    [socketClient on:@"eventListData" callback:^(NSArray * _Nonnull data, SocketAckEmitter * _Nonnull ackEmitter) {
+        [weakSelf receivedEventListData:data ackEmitter:ackEmitter];
+    }];
+    
     [socketClient on:@"error" callback:^(NSArray * _Nonnull data, SocketAckEmitter * _Nonnull ackEmitter) {
         [weakSelf socketDidEncounterErrorWithData:data];
     }];
@@ -218,26 +222,33 @@ static const int zngLogLevel = ZNGLogLevelWarning;
 #pragma mark - Typing indicator
 - (void) userDidType:(NSString *)input
 {
+    if ([input length] == 0) {
+        ZNGLogInfo(@"%s was called with no user input.  No message is sent to socket for the user clearing input, so this is ignored.", __PRETTY_FUNCTION__);
+        return;
+    }
+    
     if (![self.activeConversation isKindOfClass:[ZNGConversationServiceToContact class]]) {
         ZNGLogWarn(@"%@ was called, but the current conversation is a %@.  Ignoring.", NSStringFromSelector(_cmd), [self.activeConversation class]);
         return;
     }
     
     ZNGConversationServiceToContact * conversation = (ZNGConversationServiceToContact *)self.activeConversation;
-
-    NSString * description = nil;
     
-    if (([input length] > 0) && (conversation.session.userAuthorization != nil)) {
-        description = [NSString stringWithFormat:@"%@ is responding", [conversation.session.userAuthorization displayName]];
-    }
+    NSString * event = @"userIsReplying";
     
-    NSString * event = ([input length] > 0) ? @"lockFeed" : @"unlockFeed";
+    NSMutableDictionary * user = [[NSMutableDictionary alloc] init];
+    [user setValue:conversation.session.userAuthorization.userId forKey:@"id"];
+    [user setValue:conversation.session.userAuthorization.firstName forKey:@"first_name"];
+    [user setValue:conversation.session.userAuthorization.lastName forKey:@"last_name"];
+    [user setValue:conversation.session.userAuthorization.email forKey:@"username"];
+    [user setValue:[conversation.session.userAuthorization displayName] forKey:@"display_name"];
+    [user setValue:[conversation.session.user.avatarUri absoluteString] forKey:@"avatar_asset"];
     
     NSMutableDictionary * payload = [[NSMutableDictionary alloc] init];
-    payload[@"feedId"] = conversation.contact.contactId;
+    payload[@"feedId"] = (conversation.sequentialId > 0) ? @(conversation.sequentialId) : conversation.contact.contactId;
     payload[@"serviceId"] = conversation.service.serviceId;
-    payload[@"pendingResponse"] = input;
-    payload[@"description"] = description;
+    payload[@"type"] = @"message";
+    payload[@"user"] = user;
     
     ZNGLogInfo(@"Emitting %@ for feed %@", event, conversation.contact.contactId);
     [socketClient emit:event with:@[payload]];
@@ -245,7 +256,7 @@ static const int zngLogLevel = ZNGLogLevelWarning;
 
 - (void) userClearedInput
 {
-    [self userDidType:nil];
+    // No message is sent to socket for the user clearing input as of July 2016.
 }
 
 #pragma mark - Sockety goodness
@@ -270,6 +281,20 @@ static const int zngLogLevel = ZNGLogLevelWarning;
     ZNGLogDebug(@"Node controller bind succeeded.");
     if (self.activeConversation != nil) {
         [self subscribeForFeedUpdatesForConversation:self.activeConversation];
+    }
+}
+
+// We do not actually process the event data from socket, but we can use this event to grab our sequential ID for the feed
+//  (that does not exist in the API and should also not be used, even by socket, honestly.)
+- (void) receivedEventListData:(NSArray *)data ackEmitter:(SocketAckEmitter *)ackEmitter
+{
+    ZNGLogDebug(@"Received event data.");
+    
+    NSDictionary * eventData = [data firstObject];
+    NSNumber * feedId = eventData[@"requestFeedId"];
+    
+    if ([feedId integerValue] > 0) {
+        self.activeConversation.sequentialId = [feedId integerValue];
     }
 }
 

--- a/Pod/Classes/Models/ZNGUser.h
+++ b/Pod/Classes/Models/ZNGUser.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString * _Nullable) fullName;
 
 + (instancetype) userFromUserAuthorization:(ZNGUserAuthorization *)auth;
++ (instancetype) userFromSocketData:(NSDictionary *)data;
 
 NS_ASSUME_NONNULL_END
 

--- a/Pod/Classes/Models/ZNGUser.m
+++ b/Pod/Classes/Models/ZNGUser.m
@@ -25,6 +25,20 @@
              };
 }
 
+- (BOOL) isEqual:(ZNGUser *)other
+{
+    if (![other isKindOfClass:[ZNGUser class]]) {
+        return NO;
+    }
+    
+    return ([self.userId isEqualToString:other.userId]);
+}
+
+- (NSUInteger) hash
+{
+    return [self.userId hash];
+}
+
 + (NSValueTransformer *) avatarUriJSONTransformer
 {
     return [NSValueTransformer valueTransformerForName:MTLURLValueTransformerName];
@@ -68,5 +82,25 @@
     
     return user;
 }
+
++ (instancetype) userFromSocketData:(NSDictionary *)data
+{
+    ZNGUser * user = [[self alloc] init];
+    
+    id userIdUnknownType = data[@"id"];
+    user.userId = ([userIdUnknownType isKindOfClass:[NSString class]]) ? userIdUnknownType : [userIdUnknownType stringValue];
+    
+    user.firstName = data[@"first_name"];
+    user.lastName = data[@"last_name"];
+    user.email = data[@"username"];
+    
+    NSString * avatarAsset = data[@"avatar_asset"];
+    if ([avatarAsset isKindOfClass:[NSString class]]) {
+        [user setValue:[NSURL URLWithString:avatarAsset] forKey:NSStringFromSelector(@selector(avatarUri))];
+    }
+    
+    return user;
+}
+
 
 @end

--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -380,6 +380,7 @@ static void * KVOContext = &KVOContext;
         wiggle.keyTimes = @[ @0.0, @0.85, @0.9, @0.95, @1.0 ];
         
         wiggle.duration = 2.0;
+        wiggle.beginTime = 2.0 * 0.85; // Start just at the first wiggle
         wiggle.repeatCount = FLT_MAX;
         
         [self.typingIndicatorEmojiLabel.layer addAnimation:wiggle forKey:wiggleKey];

--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -280,6 +280,7 @@ static void * KVOContext = &KVOContext;
             [self updateForInputLockedStatus:lockedString oldStatus:oldLockedString];
         } else if ([keyPath isEqualToString:KVOReplyingUsersPath]) {
             [self updateForInputLockedStatus:self.conversation.lockedDescription oldStatus:nil];
+            [self updateTypingIndicatorEmoji];
         }
     } else {
         [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];

--- a/Pod/Classes/UI/ViewModels/Events/ZNGConversation.h
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGConversation.h
@@ -71,6 +71,12 @@ extern NSString * _Nonnull const ZNGConversationParticipantTypeGroup;
  */
 @property (nonatomic) BOOL automaticallyRefreshesOnPushNotification;
 
+/**
+ *  The sequential ID for this feed (vs. the UUID we actually use.)
+ *  We should never have this, but socket is sometimes rude and insist that we use it. :(
+ */
+@property (nonatomic, assign) NSInteger sequentialId;
+
 @property (nonatomic, readonly, nullable) ZNGMessageClient * messageClient;
 @property (nonatomic, readonly, nullable) ZNGEventClient * eventClient;
 @property (nonatomic, strong, nullable) ZNGSocketClient * socketClient;

--- a/Pod/Classes/UI/ViewModels/Events/ZNGConversation.h
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGConversation.h
@@ -94,6 +94,12 @@ extern NSString * _Nonnull const ZNGConversationParticipantTypeGroup;
 @property (nonatomic, strong, nullable) NSString * lockedDescription;
 
 /**
+ *  If any other users are replying to this conversation, ZNGUser objects corresponding to each of them will be in this array.
+ *  This will normally be an empty set, indicating no other replying users.
+ */
+@property (nonatomic, readonly, nonnull) NSOrderedSet<ZNGUser *> * replyingUsers;
+
+/**
  *  Initializing without a ZNGMessageClient is disallowed
  */
 - (nonnull id) init NS_UNAVAILABLE;
@@ -150,6 +156,9 @@ extern NSString * _Nonnull const ZNGConversationParticipantTypeGroup;
  *  @returns The most recent message in either direction
  */
 - (nullable ZNGMessage *) mostRecentMessage;
+
+#pragma mark - Typing indicator
+- (void) otherUserIsReplying:(ZNGUser * _Nonnull)user;
 
 #pragma mark - Protected methods that can be called by subclasses
 - (void) appendEvents:(nonnull NSArray<ZNGEvent *> *)events;

--- a/Pod/Classes/UI/ZNGConversation.storyboard
+++ b/Pod/Classes/UI/ZNGConversation.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="yXX-6h-nLe">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="yXX-6h-nLe">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -100,7 +100,7 @@
                                         <rect key="frame" x="0.0" y="32" width="375" height="32"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2 more messages" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J1p-JT-Rr6">
-                                                <rect key="frame" x="123.5" y="4.5" width="128.5" height="20"/>
+                                                <rect key="frame" x="124" y="4.5" width="128.5" height="20"/>
                                                 <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="17"/>
                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -145,10 +145,11 @@
                                 </subviews>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.94999999999999996" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
+                                    <constraint firstItem="qsr-lM-mNk" firstAttribute="centerY" secondItem="WHX-Je-yfE" secondAttribute="centerY" id="Aiu-pP-S0N"/>
                                     <constraint firstItem="WHX-Je-yfE" firstAttribute="top" secondItem="iWA-dO-3bV" secondAttribute="top" constant="5" id="FXV-56-Pbs"/>
                                     <constraint firstAttribute="bottom" secondItem="WHX-Je-yfE" secondAttribute="bottom" constant="5" id="RTx-Mo-5Ul"/>
-                                    <constraint firstItem="qsr-lM-mNk" firstAttribute="baseline" secondItem="WHX-Je-yfE" secondAttribute="baseline" id="VWT-CR-0uo"/>
                                     <constraint firstItem="qsr-lM-mNk" firstAttribute="leading" secondItem="WHX-Je-yfE" secondAttribute="trailing" constant="8" id="ca3-8Y-T85"/>
+                                    <constraint firstItem="WHX-Je-yfE" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="iWA-dO-3bV" secondAttribute="leading" id="cja-CJ-h45"/>
                                     <constraint firstItem="WHX-Je-yfE" firstAttribute="centerY" secondItem="iWA-dO-3bV" secondAttribute="centerY" id="mJa-8H-Ha4"/>
                                     <constraint firstAttribute="trailing" secondItem="qsr-lM-mNk" secondAttribute="trailing" constant="8" id="sPc-9k-ixE"/>
                                 </constraints>
@@ -723,10 +724,10 @@
                                 </connections>
                             </textField>
                             <view hidden="YES" clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="raY-Ot-4yE">
-                                <rect key="frame" x="0.0" y="131" width="375" height="100"/>
+                                <rect key="frame" x="0.0" y="131" width="375" height="84"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SVm-1k-Gft">
-                                        <rect key="frame" x="312" y="4.5" width="51" height="33"/>
+                                        <rect key="frame" x="312" y="-3.5" width="51" height="33"/>
                                         <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="17"/>
                                         <state key="normal" title="Search">
                                             <color key="titleColor" red="0.0" green="0.62745098040000002" blue="0.87058823529999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -736,10 +737,10 @@
                                         </connections>
                                     </button>
                                     <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="j1t-J3-wcW">
-                                        <rect key="frame" x="327.5" y="11" width="20" height="20"/>
+                                        <rect key="frame" x="327.5" y="3" width="20" height="20"/>
                                     </activityIndicatorView>
                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Room number" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6v7-ZW-0uV" customClass="JVFloatLabeledTextField">
-                                        <rect key="frame" x="16" y="54" width="110" height="46"/>
+                                        <rect key="frame" x="16" y="38" width="110" height="46"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="110" id="OAA-C6-Pj7"/>
                                             <constraint firstAttribute="height" constant="46" id="uhc-Yq-zGp"/>
@@ -754,7 +755,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </textField>
                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="100" horizontalCompressionResistancePriority="100" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="HotSOS issue name" textAlignment="natural" minimumFontSize="17" clearButtonMode="always" translatesAutoresizingMaskIntoConstraints="NO" id="wk5-1s-9rR" customClass="ZNGContactEditFloatLabeledTextField">
-                                        <rect key="frame" x="16" y="0.0" width="284" height="46"/>
+                                        <rect key="frame" x="16" y="0.0" width="284" height="30"/>
                                         <nil key="textColor"/>
                                         <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="search"/>


### PR DESCRIPTION
http://jira.zinglecorp.com:8080/browse/IOS-693

Updated the typing indicator/collision detector to use the new `userIsReplying` socket event instead of the old `feedLocked` and `feedUnlocked` events.  Those will continue to work to handle users typing in the old UI, but iOS users typing will no longer send those events, so only new UI users will see notifications for iOS users typing.

![wiggle](http://i.imgur.com/F0bq9cK.gif)