### PR TITLE
IOS-681: Top banners obscuring top text in conversations

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -298,7 +298,9 @@ static void * KVOContext = &KVOContext;
 - (void) updateTopInset
 {
     CGFloat networkStatusHeight = networkStatusLabel.intrinsicContentSize.height;
-    CGFloat topBannerHeight = (self.automationBannerOnScreenConstraint.active) ? bannerContainer.frame.size.height : 0.0;
+    CGFloat topAutomationBannerHeight = (self.automationBannerOnScreenConstraint.active) ? bannerContainer.frame.size.height : 0.0;
+    CGFloat topBlockedBannerHeight = (blockedChannelBanner.superview != nil) ? blockedChannelBanner.frame.size.height : 0.0;
+    CGFloat topBannerHeight = MAX(topBlockedBannerHeight, topAutomationBannerHeight);
     self.topContentAdditionalInset = MAX(networkStatusHeight, topBannerHeight);
 }
 

--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -255,6 +255,8 @@ static void * KVOContext = &KVOContext;
         ZNGLogInfo(@"Confirming contact due to conversation view appearance.");
         [self.conversation.contact confirm];
     }
+    
+    [self updateTopInset];
 }
 
 - (void) observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSString *,id> *)change context:(void *)context
@@ -290,9 +292,14 @@ static void * KVOContext = &KVOContext;
 - (void) notifyNetworkStatusChanged:(NSNotification *)notification
 {
     [networkStatusLabel updateWithNetworkStatus:self.conversation.session.networkLookout.status];
-    
-    CGSize networkStatusSize = networkStatusLabel.intrinsicContentSize;
-    self.topContentAdditionalInset = networkStatusSize.height;
+    [self updateTopInset];
+}
+
+- (void) updateTopInset
+{
+    CGFloat networkStatusHeight = networkStatusLabel.intrinsicContentSize.height;
+    CGFloat topBannerHeight = (self.automationBannerOnScreenConstraint.active) ? bannerContainer.frame.size.height : 0.0;
+    self.topContentAdditionalInset = MAX(networkStatusHeight, topBannerHeight);
 }
 
 - (void) updateForInputLockedStatus:(NSString *)lockedDescription oldStatus:(NSString *)oldLockedDescription
@@ -325,6 +332,8 @@ static void * KVOContext = &KVOContext;
             self.automationBannerOffScreenConstraint.active = !automationTextExists;
             [self.automationBannerContainerView layoutSubviews];
         }];
+        
+        [self updateTopInset];
     }
     
     if (bottomStatusChanged) {

--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -292,8 +292,7 @@ static void * KVOContext = &KVOContext;
     [networkStatusLabel updateWithNetworkStatus:self.conversation.session.networkLookout.status];
     
     CGSize networkStatusSize = networkStatusLabel.intrinsicContentSize;
-    UIEdgeInsets collectionViewContentInset = self.collectionView.contentInset;
-    self.collectionView.contentInset = UIEdgeInsetsMake(networkStatusSize.height, collectionViewContentInset.left, collectionViewContentInset.bottom, collectionViewContentInset.right);
+    self.topContentAdditionalInset = networkStatusSize.height;
 }
 
 - (void) updateForInputLockedStatus:(NSString *)lockedDescription oldStatus:(NSString *)oldLockedDescription


### PR DESCRIPTION
The initial attempt at this fix manually set the contentInset values for the conversation collection view.  Apparently there is a `topContentAdditionalInset` property in the message UI library we use that handles this much more reliably and does not break on device rotation.

![spinningbroken](http://forgifs.com/gallery/d/249867-2/Dog-spinning-paws-breakdancing.gif)