### PR TITLE
IOS-689: Delayed messages that have been sent will now be updated

### DIFF
--- a/Pod/Classes/Models/ZNGEvent.h
+++ b/Pod/Classes/Models/ZNGEvent.h
@@ -62,9 +62,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL) isInboundMessage;
 
 /**
- *  Returns YES if this event type is deletable.  The only event type where this is true at the moment is delayed message.
+ *  Returns YES if this event type is deletable/mutable.  The only event type where this is true at the moment is delayed message.
  */
-- (BOOL) mayBeDeleted;
+- (BOOL) isMutable;
+
+/**
+ *  Returns YES if the event has changed since the provided copy.  Always returns NO if isMutable is NO.
+ */
+- (BOOL) hasChangedSince:(ZNGEvent *)oldEvent;
 
 @end
 

--- a/Pod/Classes/Models/ZNGEvent.m
+++ b/Pod/Classes/Models/ZNGEvent.m
@@ -274,13 +274,22 @@ static NSString * const ZNGEventHotsosIssueCreated = @"hotsos_issue_creation";
     return @"Unknown event";
 }
 
-- (BOOL) mayBeDeleted
+- (BOOL) isMutable
 {
     if ([self.eventType isEqualToString:ZNGEventTypeMessage]) {
         return self.message.isDelayed;
     }
     
     return NO;
+}
+
+- (BOOL) hasChangedSince:(ZNGEvent *)oldEvent
+{
+    if ((![self isMutable]) && (![oldEvent isMutable])) {
+        return NO;
+    }
+    
+    return ([self.message hasChangedSince:oldEvent.message]);
 }
 
 @end

--- a/Pod/Classes/Models/ZNGMessage/ZNGMessage.h
+++ b/Pod/Classes/Models/ZNGMessage/ZNGMessage.h
@@ -63,6 +63,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (ZNGCorrespondent * _Nullable) contactCorrespondent;
 
+/**
+ *  Returns YES if this message has been changed.  Only true when a delayed message is finally sent at the moment.
+ */
+- (BOOL) hasChangedSince:(ZNGMessage *)oldMessage;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Pod/Classes/Models/ZNGMessage/ZNGMessage.m
+++ b/Pod/Classes/Models/ZNGMessage/ZNGMessage.m
@@ -83,6 +83,11 @@
     return self.triggeredByUser.userId;
 }
 
+- (BOOL) hasChangedSince:(ZNGMessage *)oldMessage
+{
+    return (self.isDelayed != oldMessage.isDelayed);
+}
+
 #pragma mark - Message data for <JSQMessageData>
 - (NSString *)senderId
 {


### PR DESCRIPTION
When data arrived indicating a delayed message had been sent, the new data was being ignored because events were treated as immutable.  Message with isDelayed set (either in new or old data) will now be checked for changes when data including them arrives.

![telegraph](http://i.imgur.com/fpWq4eh.gif)