### PR TITLE
IOS-679: Contact/segment updates via push notifications

### DIFF
--- a/Pod/Classes/Models/ZNGContact/ZNGContact.m
+++ b/Pod/Classes/Models/ZNGContact/ZNGContact.m
@@ -95,6 +95,10 @@ static NSString * const ParameterNameClosed = @"is_closed";
         self.labels = contact.labels;
     }
     
+    if (![self.groups isEqualToArray:contact.groups]) {
+        self.groups = contact.groups;
+    }
+    
     if (![self.updatedAt isEqualToDate:contact.updatedAt]) {
         self.updatedAt = contact.updatedAt;
     }
@@ -420,6 +424,14 @@ static NSString * const ParameterNameClosed = @"is_closed";
 
 - (BOOL) changedSince:(nullable ZNGContact *)old
 {
+    // Group changes are not reflected in the updatedAt timestamp, so that must be checked explicitly
+    NSSet * groupSet = [NSSet setWithArray:self.groups];
+    NSSet * oldGroupSet = [NSSet setWithArray:old.groups];
+    
+    if (![groupSet isEqualToSet:oldGroupSet]) {
+        return YES;
+    }
+    
     if ((old.updatedAt == nil) || (self.updatedAt == nil)) {
         return YES;
     }
@@ -452,6 +464,10 @@ static NSString * const ParameterNameClosed = @"is_closed";
     NSSet * oldLabelsSet = [NSSet setWithArray:old.labels];
     BOOL sameLabels = ([labelsSet isEqualToSet:oldLabelsSet]);
     
+    NSSet * groupsSet = [NSSet setWithArray:self.groups];
+    NSSet * oldGroupsSet = [NSSet setWithArray:old.groups];
+    BOOL sameGroups = ([groupsSet isEqualToSet:oldGroupsSet]);
+    
     if (sameChannels) {
         // We have the same channel IDs, but some of the channels may be changed
         [[self channelsWithValues] enumerateObjectsUsingBlock:^(ZNGChannel * _Nonnull channel, NSUInteger idx, BOOL * _Nonnull stop) {
@@ -464,7 +480,7 @@ static NSString * const ParameterNameClosed = @"is_closed";
         }];
     }
 
-    return (!sameCustomFields || !sameChannels || !sameConfirmed || !sameLabels);
+    return (!sameCustomFields || !sameChannels || !sameConfirmed || !sameLabels || !sameGroups);
 }
 
 - (BOOL) visualRefreshSinceOldMessageShouldAnimate:(ZNGContact *)old

--- a/Pod/Classes/Models/ZNGContactGroup.m
+++ b/Pod/Classes/Models/ZNGContactGroup.m
@@ -12,6 +12,20 @@
 
 @implementation ZNGContactGroup
 
+- (NSUInteger) hash
+{
+    return [self.groupId hash];
+}
+
+- (BOOL) isEqual:(ZNGContactGroup *)other
+{
+    if (![other isKindOfClass:[ZNGContactGroup class]]) {
+        return NO;
+    }
+    
+    return ([other.groupId isEqualToString:self.groupId]);
+}
+
 + (NSDictionary*) JSONKeyPathsByPropertyKey
 {
     return @{

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
@@ -13,6 +13,7 @@
 #import "ZingleSDK.h"
 #import "ZNGContactDataSetBuilder.h"
 #import "ZNGLabel.h"
+#import "ZingleAccountSession.h"
 
 static const int zngLogLevel = ZNGLogLevelDebug;
 
@@ -495,6 +496,13 @@ NSString * const ZNGInboxDataSetSortDirectionDescending = @"desc";
                         if ([newContact changedSince:contact]) {
                             ZNGLogDebug(@"Refreshing %@, last updated %.0f seconds ago", [newContact fullName], [[NSDate date] timeIntervalSinceDate:newContact.updatedAt]);
                             [mutableContacts replaceObjectAtIndex:idx+startIndex withObject:incomingContacts[idx]];
+                            
+                            ZingleAccountSession * session = (ZingleAccountSession *)self.contactClient.session;
+                            
+                            if ([session isKindOfClass:[ZingleAccountSession class]]) {
+                                [session contactChanged:newContact];
+                            }
+                            
                         } else {
                             ZNGLogVerbose(@"Failing to replace %@ since the updated at timestamp has not changed.", [contact fullName]);
                         }

--- a/Pod/Classes/ZingleAccountSession.h
+++ b/Pod/Classes/ZingleAccountSession.h
@@ -109,6 +109,13 @@ extern NSString * const ZingleUserChangedDetailedEventsPreferenceNotification;
 #pragma mark - User data
 - (void) updateUserData;
 
+#pragma mark - External data
+/**
+ *  If a contact data change is detected elsewhere, such as through the /contacts/ end point somewhere else,
+ *   calling this method ensures that any cached data for that contact (such as within conversations) is updated.
+ */
+- (void) contactChanged:(ZNGContact *)contact;
+
 #pragma mark - Push notifications
 /**
  *  Asks the server to send a push notification.  Can be used to test pushes from top to bottom by listening for a ZNGPushNotificationReceived notification.
@@ -123,7 +130,7 @@ extern NSString * const ZingleUserChangedDetailedEventsPreferenceNotification;
  *  If no such conversation yet exists in our data, a blank conversation will be returned.  It will populate itself
  *   as soon as a network request returns.
  *
- *  @param contactId The identifier for the desired contact
+ *  @param contact The desired contact
  */
 - (ZNGConversationServiceToContact *) conversationWithContact:(ZNGContact *)contact;
 

--- a/Pod/Classes/ZingleAccountSession.m
+++ b/Pod/Classes/ZingleAccountSession.m
@@ -563,6 +563,22 @@ NSString * const ZingleUserChangedDetailedEventsPreferenceNotification = @"Zingl
 }
 
 #pragma mark - Messaging
+- (void) contactChanged:(ZNGContact *)contact
+{
+    NSString * contactId = contact.contactId;
+    
+    if ([contactId length] == 0) {
+        ZNGLogWarn(@"%s called with no contact ID supplied.", __PRETTY_FUNCTION__);
+        return;
+    }
+    
+    ZNGConversationServiceToContact * conversation = [self.conversationCache objectForKey:contactId];
+    
+    if ((conversation != nil) && ([contact changedSince:conversation.contact])) {
+        conversation.contact = contact;
+    }
+}
+
 - (ZNGConversationServiceToContact *) conversationWithContact:(ZNGContact *)contact;
 {
     // Do we have a cached version of this conversation already?


### PR DESCRIPTION
Any push notification regarding the current service will now cause inbox data to refresh (thus displaying any changes to segments) and will update any changed contact data that is cached in conversation objects.

![rain](https://68.media.tumblr.com/7f0a4984f71cd476c9f906abdb8ca26d/tumblr_nn8sfpmDuI1qkpqezo1_500.gif)