### PR TITLE
IOS-717: Handle disappearing active channel

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -959,6 +959,13 @@ static void * KVOContext = &KVOContext;
         shouldDisableInput = YES;
     }
     
+    // Did our channel disappear?
+    if (![self.conversation.contact.channels containsObject:self.conversation.channel]) {
+        ZNGLogWarn(@"Currently selected channel is not present in the contact data.  Deselecting.");
+        self.inputToolbar.noSelectedChannelText = @"Select a channel";
+        shouldDisableInput = YES;
+    }
+    
     self.inputToolbar.currentChannel = self.conversation.channel;
     BOOL someKindOfBlock = (self.conversation.channel.blockOutbound || self.conversation.channel.blockInbound);
     


### PR DESCRIPTION
'Select a channel' will be displayed instead of an ominously empty channel selection.  The input is locked until a channel is selected.

![ghost](https://media.giphy.com/media/VvALxeoS5LerC/giphy.gif)