### PR TITLE
IOS-724: Stopped peeing on grayscale colors when serializing them

### DIFF
--- a/Pod/Classes/Models/ZNGContactGroup.m
+++ b/Pod/Classes/Models/ZNGContactGroup.m
@@ -46,6 +46,12 @@
         
         const CGFloat *components = CGColorGetComponents(color.CGColor);
         
+        if (CGColorGetNumberOfComponents(color.CGColor) < 4) {
+            // Grayscale
+            long whiteness = lroundf(components[0] * 255.0);
+            return [NSString stringWithFormat:@"#%02lX%02lX%02lX", whiteness, whiteness, whiteness];
+        }
+        
         CGFloat r = components[0];
         CGFloat g = components[1];
         CGFloat b = components[2];


### PR DESCRIPTION
http://jira.zinglecorp.com:8080/browse/IOS-724

Null tag/segment colors sent by the server were eventually turning from gray to yellow due to a bug in serializing grayscale colors into HTML codes.

![jarate](http://i.imgur.com/FxV17Ntl.jpg)