### PR TITLE
IOS-727: Fix vanishing subsequent image attachments

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
@@ -1040,6 +1040,8 @@ static void * ZNGConversationKVOContext  =   &ZNGConversationKVOContext;
     
     [self.inputToolbar.contentView.textView becomeFirstResponder];
     [self.inputToolbar toggleSendButtonEnabled];
+    
+    [self updateUUID];
 }
 
 #pragma mark - Unread banner


### PR DESCRIPTION
http://jira.zinglecorp.com:8080/browse/IOS-727

Attaching more than one image in a row would not reset the hidden UUID, causing the server to discard future messages as duplicates.

![spooky](http://i.imgur.com/1XqrLsUm.jpg)