### PR TITLE
IOS-707: Fixed iOS 11 edit contact row sizing

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGContactEditViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGContactEditViewController.m
@@ -83,7 +83,6 @@ static NSString * const SelectLabelSegueIdentifier = @"selectLabel";
     [self.tableView registerNib:headerNib forHeaderFooterViewReuseIdentifier:HeaderReuseIdentifier];
     [self.tableView registerNib:footerNib forHeaderFooterViewReuseIdentifier:FooterReuseIdentifier];
     
-    self.tableView.estimatedRowHeight = 44.0;
     self.tableView.tableHeaderView = [[UIView alloc] initWithFrame:CGRectMake(0.0, 0.0, self.tableView.bounds.size.width, 10.0)];
     self.tableView.tableFooterView = [[UIView alloc] initWithFrame:CGRectMake(0.0, 0.0, self.tableView.bounds.size.width, 10.0)];
     

--- a/Pod/Classes/UI/ZNGConversation.storyboard
+++ b/Pod/Classes/UI/ZNGConversation.storyboard
@@ -877,7 +877,7 @@
                                     <constraint firstAttribute="height" constant="32" id="hKn-r9-8Op"/>
                                 </constraints>
                             </view>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="emI-L2-W9W">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="30" sectionFooterHeight="10" translatesAutoresizingMaskIntoConstraints="NO" id="emI-L2-W9W">
                                 <rect key="frame" x="0.0" y="96" width="375" height="571"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <prototypes>


### PR DESCRIPTION
http://jira.zinglecorp.com:8080/browse/IOS-707

Automatic table row sizing was not setup correctly and was breaking when built with the iOS 11 SDK.

![costume](http://i.imgur.com/8DtFrjzm.jpg)