### PR TITLE
IOS-707: Fixed a contact edit table row regression 

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGContactEditViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGContactEditViewController.m
@@ -83,6 +83,8 @@ static NSString * const SelectLabelSegueIdentifier = @"selectLabel";
     [self.tableView registerNib:headerNib forHeaderFooterViewReuseIdentifier:HeaderReuseIdentifier];
     [self.tableView registerNib:footerNib forHeaderFooterViewReuseIdentifier:FooterReuseIdentifier];
     
+    self.tableView.estimatedRowHeight = 44.0;
+    
     self.tableView.tableHeaderView = [[UIView alloc] initWithFrame:CGRectMake(0.0, 0.0, self.tableView.bounds.size.width, 10.0)];
     self.tableView.tableFooterView = [[UIView alloc] initWithFrame:CGRectMake(0.0, 0.0, self.tableView.bounds.size.width, 10.0)];
     


### PR DESCRIPTION
The fix for building with the iOS 11 SDK in https://github.com/Zingle/ios-sdk/pull/101 caused a regression when built with the iOS 10 SDK.  This fixes it with a row sizing logic compromise.

![whataguy](https://camo.githubusercontent.com/a407232317dcf386807914d9e819736ff0bf9386/687474703a2f2f692e696d6775722e636f6d2f38447446726a7a6d2e6a7067)