### PR TITLE
IOS-740: Open and close brace confusion crash

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
@@ -817,8 +817,8 @@ static void * ZNGConversationKVOContext  =   &ZNGConversationKVOContext;
         
         if (deletingChar == '}') {
             // Can we find a matching {?
-            NSRange openingBraceRange = [textView.text rangeOfString:@"{" options:NSBackwardsSearch];
-            
+            NSRange openingBraceRange = [[textView.text substringToIndex:range.location] rangeOfString:@"{" options:NSBackwardsSearch];
+
             if (openingBraceRange.location != NSNotFound) {
                 // We found a template to delete.  Delete it.
                 NSRange customFieldRange = NSMakeRange(openingBraceRange.location, range.location-openingBraceRange.location+1);


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-740

Fixed a crash if a `}` character is deleted with a `{` character somewhere later in the text.  How silly.

![kaboom](https://i.imgur.com/YyVq7bs.jpg)