### PR TITLE
Replaced ZNGUser with ZNGUserAuthorization

### DIFF
--- a/Example/Tests/TestAccountSession.m
+++ b/Example/Tests/TestAccountSession.m
@@ -229,7 +229,7 @@
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 }
 
-- (void) testUserAuthorizationAndUserInfoAvailableImmediately
+- (void) testUserAuthorizationAvailableImmediately
 {
     ZingleAccountSession * session = [ZingleSDK accountSessionWithToken:@"token" key:@"key"];
     
@@ -265,7 +265,6 @@
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
     
     XCTAssertNotNil([session.userAuthorization displayName], @"Authenticated user information (ZNGUserAuthorization) should be available on login.");
-    XCTAssertNotNil(session.user.userId, @"User information (ZNGUser) should be available on login.");
 }
 
 - (void) testRegisteredForPushNotifications

--- a/Pod/Classes/Clients/ZNGSocketClient.m
+++ b/Pod/Classes/Clients/ZNGSocketClient.m
@@ -246,7 +246,7 @@ static const int zngLogLevel = ZNGLogLevelWarning;
     [user setValue:conversation.session.userAuthorization.lastName forKey:@"last_name"];
     [user setValue:conversation.session.userAuthorization.email forKey:@"username"];
     [user setValue:[conversation.session.userAuthorization displayName] forKey:@"display_name"];
-    [user setValue:[conversation.session.user.avatarUri absoluteString] forKey:@"avatar_asset"];
+    [user setValue:[conversation.session.userAuthorization.avatarUri absoluteString] forKey:@"avatar_asset"];
     
     NSMutableDictionary * payload = [[NSMutableDictionary alloc] init];
     payload[@"feedId"] = (conversation.sequentialId > 0) ? @(conversation.sequentialId) : conversation.contact.contactId;

--- a/Pod/Classes/Models/ZNGUser.m
+++ b/Pod/Classes/Models/ZNGUser.m
@@ -79,6 +79,8 @@
     user.userId = auth.userId;
     user.email = auth.email;
     user.title = auth.title;
+    user.serviceIds = auth.serviceIds;
+    user.avatarUri = auth.avatarUri;
     
     return user;
 }

--- a/Pod/Classes/Models/ZNGUserAuthorization.h
+++ b/Pod/Classes/Models/ZNGUserAuthorization.h
@@ -10,13 +10,17 @@
 
 @interface ZNGUserAuthorization : MTLModel<MTLJSONSerializing>
 
-@property (nonatomic, strong) NSString* authorizationClass;
-@property (nonatomic, strong) NSString * userId;
-@property (nonatomic, strong) NSString * email;
-@property (nonatomic, strong) NSString * firstName;
-@property (nonatomic, strong) NSString * lastName;
-@property (nonatomic, strong) NSString * title;
+@property (nonatomic, strong, nullable) NSString * authorizationClass;
+@property (nonatomic, strong, nullable) NSString * userId;
+@property (nonatomic, strong, nullable) NSString * username;
+@property (nonatomic, strong, nullable) NSString * email;
+@property (nonatomic, strong, nullable) NSString * firstName;
+@property (nonatomic, strong, nullable) NSString * lastName;
+@property (nonatomic, strong, nullable) NSString * title;
+@property (nonatomic, strong, nullable) NSArray<NSString *> * accountIds;
+@property (nonatomic, strong, nullable) NSArray<NSString *> * serviceIds;
+@property (nonatomic, strong, nullable) NSURL * avatarUri;
 
-- (NSString *) displayName;
+- (NSString * _Nullable) displayName;
 
 @end

--- a/Pod/Classes/Models/ZNGUserAuthorization.m
+++ b/Pod/Classes/Models/ZNGUserAuthorization.m
@@ -15,12 +15,20 @@
 {
     return @{
              @"authorizationClass" : @"authorization_class",
-             @"userId" : @"id",
+             NSStringFromSelector(@selector(userId)) : @"id",
              @"email" : @"email",
              @"firstName" : @"first_name",
              @"lastName" : @"last_name",
-             @"title" : @"title"
+             @"title" : @"title",
+             NSStringFromSelector(@selector(accountIds)): @"account_uuids",
+             NSStringFromSelector(@selector(serviceIds)): @"service_uuids",
+             NSStringFromSelector(@selector(avatarUri)): @"avatar_uri",
              };
+}
+
++ (NSValueTransformer *) avatarUriJSONTransformer
+{
+    return [NSValueTransformer valueTransformerForName:MTLURLValueTransformerName];
 }
 
 - (NSString *)displayName

--- a/Pod/Classes/UI/ViewModels/Events/ZNGConversationServiceToContact.m
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGConversationServiceToContact.m
@@ -360,7 +360,7 @@ static NSString * const ChannelsKVOPath = @"contact.channels";
 
 - (void) addAvatarToSendingEvent:(ZNGEvent *)event
 {
-    event.triggeredByUser = self.session.user;
+    event.triggeredByUser = [ZNGUser userFromUserAuthorization:self.session.userAuthorization];
 }
 
 - (void) triggerAutomation:(ZNGAutomation *)automation completion:(void (^)(BOOL success))completion

--- a/Pod/Classes/ZingleAccountSession.h
+++ b/Pod/Classes/ZingleAccountSession.h
@@ -56,7 +56,6 @@ extern NSString * const ZingleUserChangedDetailedEventsPreferenceNotification;
  *  Meta data about the current user.
  */
 @property (nonatomic, strong, nullable) ZNGUserAuthorization * userAuthorization;
-@property (nonatomic, strong, nullable) ZNGUser * user;
 
 /**
  *  If set, the service object will be refreshed whenever returning from the background (but no more often than every ten minutes.)

--- a/Pod/Classes/ZingleAccountSession.m
+++ b/Pod/Classes/ZingleAccountSession.m
@@ -488,6 +488,7 @@ NSString * const ZingleUserChangedDetailedEventsPreferenceNotification = @"Zingl
     
     [self.userAuthorizationClient userAuthorizationWithSuccess:^(ZNGUserAuthorization * theUserAuthorization, ZNGStatus *status) {
         self.userAuthorization = theUserAuthorization;
+        
         [[ZNGAnalytics sharedAnalytics] trackLoginSuccessWithToken:self.token andUserAuthorizationObject:theUserAuthorization];
         dispatch_semaphore_signal(semaphore);
     } failure:^(ZNGError *error) {
@@ -502,18 +503,6 @@ NSString * const ZingleUserChangedDetailedEventsPreferenceNotification = @"Zingl
         // We failed to get the user ID; we cannot get the user object below.
         return;
     }
-    
-    semaphore = dispatch_semaphore_create(0);
-    
-    [self.userClient userWithId:self.userAuthorization.userId success:^(ZNGUser *user, ZNGStatus *status) {
-        self.user = user;
-        dispatch_semaphore_signal(semaphore);
-    } failure:^(ZNGError *error) {
-        ZNGLogError(@"Unable to retrieve user object for user %@", self.userAuthorization.userId);
-        dispatch_semaphore_signal(semaphore);
-    }];
-    
-    dispatch_semaphore_wait(semaphore, tenSecondTimeout);
 }
 
 - (void) notifyShowDetailedEventsPreferenceChanged:(NSNotification *)notification


### PR DESCRIPTION
The user object retrievable at the base URL of the API should now include all information we used to acquire through /users/.  To avoid some auth problems with users across different accounts (https://zingle.atlassian.net/browse/IOS-737), the separate requests to /users/ have been removed.  SDK users can either obtain this information from the `ZNGUserAuthorization` object or the convenience constructor that can make a `ZNGUser` from a `ZNGUserAuthorization` object.

![lost cosmonaut grigoriy nelyubov](https://user-images.githubusercontent.com/1328743/30933437-6b9cadf2-a37f-11e7-9ac9-dfb0dda7c71a.jpg)
