### PR TITLE
Warning cleanup

### DIFF
--- a/Pod/Classes/Clients/ZNGBaseClient.m
+++ b/Pod/Classes/Clients/ZNGBaseClient.m
@@ -6,7 +6,7 @@
 //
 //
 
-#import <AFNetworking/AFNetworking.h>
+#import <AFNetworking/AFHTTPSessionManager.h>
 #import "ZNGBaseClient.h"
 #import "ZNGLogging.h"
 #import "ZingleSession.h"

--- a/Pod/Classes/Clients/ZNGHotsosClient.m
+++ b/Pod/Classes/Clients/ZNGHotsosClient.m
@@ -7,7 +7,7 @@
 //
 
 #import "ZNGHotsosClient.h"
-#import <AFNetworking/AFNetworking.h>
+#import <AFNetworking/AFHTTPSessionManager.h>
 #import "ZNGLogging.h"
 #import "ZNGService.h"
 #import "ZNGSettingsField.h"

--- a/Pod/Classes/Clients/ZNGSocketClient.m
+++ b/Pod/Classes/Clients/ZNGSocketClient.m
@@ -9,7 +9,7 @@
 #import "ZNGSocketClient.h"
 #import "ZNGLogging.h"
 #import "ZingleSession.h"
-#import <AFNetworking/AFNetworking.h>
+#import <AFNetworking/AFHTTPSessionManager.h>
 #import "NSURL+Zingle.h"
 #import "ZNGConversationServiceToContact.h"
 #import "ZNGConversationContactToService.h"

--- a/Pod/Classes/Clients/ZNGUserClient.h
+++ b/Pod/Classes/Clients/ZNGUserClient.h
@@ -20,12 +20,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Avatars
 - (void) deleteAvatarForUserWithId:(NSString *)userId
-                           success:(void (^ _Nullable)())success
+                           success:(void (^ _Nullable)(void))success
                            failure:(void (^ _Nullable)(ZNGError * error))failure;
 
 - (void) uploadAvatar:(UIImage *)avatarImage
         forUserWithId:(NSString *)userId
-              success:(void (^ _Nullable)())success
+              success:(void (^ _Nullable)(void))success
               failure:(void (^ _Nullable)(ZNGError * error))failure;
 
 NS_ASSUME_NONNULL_END

--- a/Pod/Classes/Clients/ZNGUserClient.m
+++ b/Pod/Classes/Clients/ZNGUserClient.m
@@ -28,7 +28,7 @@ static const int zngLogLevel = ZNGLogLevelWarning;
 }
 
 - (void) deleteAvatarForUserWithId:(NSString *)userId
-                           success:(void (^)())success
+                           success:(void (^)(void))success
                            failure:(void (^)(ZNGError * error))failure
 {
     NSString * path = [NSString stringWithFormat:@"accounts/%@/users/%@/avatar", self.accountId, userId];
@@ -44,7 +44,7 @@ static const int zngLogLevel = ZNGLogLevelWarning;
 
 - (void) uploadAvatar:(UIImage *)avatarImage
         forUserWithId:(NSString *)userId
-              success:(void (^)())success
+              success:(void (^)(void))success
               failure:(void (^)(ZNGError * error))failure
 {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{

--- a/Pod/Classes/Models/ZNGError.m
+++ b/Pod/Classes/Models/ZNGError.m
@@ -7,7 +7,7 @@
 //
 
 #import "ZNGError.h"
-#import <AFNetworking/AFNetworking.h>
+#import <AFNetworking/AFHTTPSessionManager.h>
 
 @implementation ZNGError
 

--- a/Pod/Classes/UI/Categories/UIColor+ZingleSDK.h
+++ b/Pod/Classes/UI/Categories/UIColor+ZingleSDK.h
@@ -69,7 +69,7 @@
 /**
  *  Creates and returns a new color object from a hex color value.
  *
- *  @param value A string hex value example: #D4D4D4
+ *  @param hexString A string hex value example: #D4D4D4
  *
  *  @return A new color object matching a the RGB hex value.
  */

--- a/Pod/Classes/UI/Controllers/ZNGConversationViewController.h
+++ b/Pod/Classes/UI/Controllers/ZNGConversationViewController.h
@@ -56,50 +56,43 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  Sets the background color of the incoming bubble.
- *
- *  @param incomingBubbleColor Defaults to Zingle light gray.
+ *  Defaults to Zingle light gray.
  */
 @property (nonatomic, strong) UIColor *incomingBubbleColor;
 
 /**
  *  Sets the background color of the outgoing bubble.
- *
- *  @param outgoingBubbleColor Defaults to default Zingle blue
+ *  Defaults to default Zingle blue.
  */
 @property (nonatomic, strong) UIColor *outgoingBubbleColor;
 
 /**
  *  Sets the background color of internal note bubbles.
- *
- *  @param internalNoteColor Defaults to zng_note_yellow
+ *  Defaults to zng_note_yellow
  */
 @property (nonatomic, strong) UIColor * internalNoteColor;
 
 /**
  *  Sets the text color of the incoming message text.
- *
- *  @param incomingTextColor Defaults to Zingle gray text color
+ *  Defaults to Zingle gray text color
  */
 @property (nonatomic, strong) UIColor *incomingTextColor;
 
 /**
  *  Sets the text color of the outgoing message text.
- *
- *  @param outgoingTextColor Defaults to Zingle gray text color
+ *  Defaults to Zingle gray text color
  */
 @property (nonatomic ,strong) UIColor *outgoingTextColor;
 
 /**
  *  Sets the text color of internal notes.
- *
- *  @param internalNoteTextColor Defaults to Zingle gray text color
+ *  Defaults to Zingle gray text color
  */
 @property (nonatomic, strong) UIColor * internalNoteTextColor;
 
 /**
  *  Sets the text color of the label on top of the message bubble.
- *
- *  @param authorTextColor Defaults to [UIColor lightGrayColor]
+ *  Defaults to [UIColor lightGrayColor]
  */
 @property (nonatomic, strong) UIColor *authorTextColor;
 
@@ -143,9 +136,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  Sets whether or not the messages should be automatically marked as read.
- *
- *  @param autoMarkAsReadEnabled If YES, then the messages are automatically marked as read.
- *  Default value is NO.
+ *  If YES, then the messages are automatically marked as read.
+ *  Defaults to NO.
  */
 @property (nonatomic, assign, getter=isAutoMarkAsReadEnabled) BOOL autoMarkAsReadEnabled;
 

--- a/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
@@ -705,7 +705,7 @@ static void * ZNGConversationKVOContext  =   &ZNGConversationKVOContext;
 }
 
 // Using method stolen from http://stackoverflow.com/a/26401767/3470757 to insert/reload without scrolling
-- (void) performCollectionViewUpdatesWithoutScrollingFromBottom:(void (^)())updates
+- (void) performCollectionViewUpdatesWithoutScrollingFromBottom:(void (^)(void))updates
 {
     CGFloat bottomOffset = self.collectionView.contentSize.height - self.collectionView.contentOffset.y;
 

--- a/Pod/Classes/ZingleContactSession.h
+++ b/Pod/Classes/ZingleContactSession.h
@@ -94,9 +94,6 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param key Security key for Zingle API user
  *  @param channelTypeId An identifier for the channel type, e.g. the identifier for Big Hotel Messaging System
  *  @param channelValue The channel value for the current user, e.g. joeSchmoe97 for the user name in Big Hotel Messaging System
- *  @param contactServiceChooser Optional block to be used to select a contact service once we obtain the list of available contact services.  May be neglected or return nil.
- *   This block is retained indefinitely, so weak references should be used or the contactServiceChooser property should be set to nil if no longer needed.
- *  @param errorHandler Optional block that is called every time an error is received.
  */
 - (instancetype) initWithToken:(NSString *)token
                            key:(NSString *)key

--- a/Pod/Classes/ZingleContactSession.m
+++ b/Pod/Classes/ZingleContactSession.m
@@ -7,7 +7,7 @@
 //
 
 #import "ZingleContactSession.h"
-#import <AFNetworking/AFNetworking.h>
+#import <AFNetworking/AFHTTPSessionManager.h>
 #import "ZNGLogging.h"
 #import "ZNGContactClient.h"
 #import "ZNGContactServiceClient.h"

--- a/Pod/Classes/ZingleSession.m
+++ b/Pod/Classes/ZingleSession.m
@@ -8,7 +8,7 @@
 
 #import "ZingleSession.h"
 #import "ZNGLogging.h"
-#import <AFNetworking/AFNetworking.h>
+#import <AFNetworking/AFHTTPSessionManager.h>
 #import "ZNGAccountClient.h"
 #import "ZNGContactServiceClient.h"
 #import "ZNGNotificationsClient.h"

--- a/Pod/Classes/ZingleSession.m
+++ b/Pod/Classes/ZingleSession.m
@@ -303,7 +303,7 @@ void __applicationDidReceiveRemoteNotification(id self, SEL _cmd, UIApplication 
     
     NSString * tokenString = [self _pushNotificationDeviceTokenAsHexString];
     
-    void (^registerForNotifications)() = ^{
+    void (^registerForNotifications)(void) = ^{
         [self.notificationsClient registerForNotificationsWithDeviceId:tokenString withServiceIds:serviceIds success:^(ZNGStatus *status) {
             ZNGLogDebug(@"Registered for push notifications successfully as %@", tokenString);
         } failure:^(ZNGError *error) {

--- a/ZingleSDK.podspec
+++ b/ZingleSDK.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Pod/Classes/**/*.{h,m}'
   s.resources = ['Pod/Assets/**/*', 'Pod/Classes/UI/**/*.{xib,storyboard}']
 
-  s.dependency 'AFNetworking'
+  s.dependency 'AFNetworking/NSURLSession'
   s.dependency 'JVFloatLabeledTextField'  
   s.dependency 'Mantle'
   s.dependency 'CocoaLumberjack'


### PR DESCRIPTION
Cleaned up some Xcode 9 warnings regarding documentation comments and block declarations and switched to a more specific subspec of AFNetworking to avoid similar warnings in its UI tools.

![funny-iphone-vs-ipad-magnifying-glass](https://user-images.githubusercontent.com/1328743/31413683-615a821a-adcf-11e7-9ad4-5f5e8a81ff7a.jpg)
