### PR TITLE
IOS-747: Removed "delete" button that really meant "crash"

### DIFF
--- a/Pod/Classes/UI/Views/ZNGConversationTextView.m
+++ b/Pod/Classes/UI/Views/ZNGConversationTextView.m
@@ -95,7 +95,7 @@ static const int zngLogLevel = ZNGLogLevelWarning;
         if (range.length > 0) {
             if (action == @selector(cut:) || action == @selector(copy:) ||
                 action == @selector(select:) || action == @selector(selectAll:) ||
-                action == @selector(paste:) || action ==@selector(delete:)) {
+                action == @selector(paste:)) {
                 canPerform = YES;
             }
         } else {


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-747

You have to love discovering a button in your app that causes a crash 100% of the time when pressed and has been around forever.

![mines](https://j.gifs.com/1w399P.gif)