### PR TITLE
IOS-748: Update for iOS 11 photo library permission changes

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
@@ -993,6 +993,10 @@ static void * ZNGConversationKVOContext  =   &ZNGConversationKVOContext;
     
     // Otherwise, we are either pre iOS 11 or do not yet have permission.  Either way, we get to go on a trip to PHPhotoLibrary town.
     // First, ensure that we have an image URL that we can later use with PHImageManager.
+    // Note that UIImagePickerControllerReferenceURL is supposed to be deprecated in iOS 11, but I cannot find any other way to access
+    //  the PHAsset passed in the image picker callback the very first time it is done.  The alternative is to ask the user for permission
+    //  for photo library access up front before an image is selected.  That would avoid a deprecated dictionary key at the expense of a
+    //  slightly worse user experience.
     NSURL * url = info[UIImagePickerControllerReferenceURL];
 
     if (url == nil) {


### PR DESCRIPTION
iOS no longer asks a user to grant permission when an app first browses the photo library; the user is asked permission only after an image is selected for the app to use.

This change and our usage of `PHImageManager` caused the very first image attachment after a fresh install to fail on iOS 11 at the same time as access to the photo library was requested.

![troll](https://i.imgur.com/wJvl59fl.jpg)