### PR TITLE
IOS-746: Changed photo picker to popover

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
@@ -927,6 +927,21 @@ static void * ZNGConversationKVOContext  =   &ZNGConversationKVOContext;
     picker.delegate = self;
     picker.allowsEditing = NO;
     picker.sourceType = cameraMode ? UIImagePickerControllerSourceTypeCamera : UIImagePickerControllerSourceTypePhotoLibrary;
+    
+    // For iPads showing the photo library, the UIImagePickerController must be presented as a popover (per UIImagePickerController documentation).
+    if ((!cameraMode) && ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad)) {
+        UIView * sourceView = self.inputToolbar.contentView;
+        
+        if ([sourceView isKindOfClass:[ZNGServiceConversationToolbarContentView class]]) {
+            ZNGServiceConversationToolbarContentView * toolbarContentView = (ZNGServiceConversationToolbarContentView *)sourceView;
+            sourceView = toolbarContentView.imageButton;
+        }
+        
+        picker.modalPresentationStyle = UIModalPresentationPopover;
+        picker.popoverPresentationController.sourceView = sourceView;
+        picker.popoverPresentationController.sourceRect = sourceView.bounds;
+    }
+    
     [self presentViewController:picker animated:YES completion:nil];
 }
 


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-746

The `UIImagePickerController` documentation says that this is required, though it mostly worked as a modal view previously.  This change will avoid IOS-746's odd landscape/portrait issue on iPad.

![9b4bd921689affb77c3d988a643782f6--locks-smartphone](https://user-images.githubusercontent.com/1328743/32078454-d6b28aec-ba5b-11e7-912f-91c4244824fb.jpg)
