### PR TITLE
IOS-744: Fixed an inconsistent transparency issue with delayed messages

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
@@ -1474,7 +1474,7 @@ static void * ZNGConversationKVOContext  =   &ZNGConversationKVOContext;
         JSQMessagesCollectionViewCell * cell = (JSQMessagesCollectionViewCell *)[super collectionView:collectionView cellForItemAtIndexPath:indexPath];
         cell.cellTopLabel.numberOfLines = 0;    // Support multiple lines
         
-        cell.alpha = (event.sending || event.message.isDelayed) ? 0.5 : 1.0;
+        cell.messageBubbleImageView.alpha = (event.sending || event.message.isDelayed) ? 0.5 : 1.0;
         
         if (event.message.isDelayed) {
             [indexPathsOfVisibleCellsWithRelativeTimesToRefresh addObject:indexPath];


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-744

Something magical and mysterious was restoring normal 1.0 alpha to message cells, breaking the intentionally transparent delayed message cells.  These cells now make their backgrounds transparent instead of the entire cell, avoiding whatever ghost was restoring their opacity.

![spooky](https://i.imgur.com/6y5qkYLl.jpg)