### PR TITLE
IOS-750: Restored faded appearance of delayed image messages

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
@@ -1530,7 +1530,9 @@ static void * ZNGConversationKVOContext  =   &ZNGConversationKVOContext;
         JSQMessagesCollectionViewCell * cell = (JSQMessagesCollectionViewCell *)[super collectionView:collectionView cellForItemAtIndexPath:indexPath];
         cell.cellTopLabel.numberOfLines = 0;    // Support multiple lines
         
-        cell.messageBubbleImageView.alpha = (event.sending || event.message.isDelayed) ? 0.5 : 1.0;
+        CGFloat contentAlpha = (event.sending || event.message.isDelayed) ? 0.5 : 1.0;
+        cell.messageBubbleImageView.alpha = contentAlpha;
+        cell.mediaView.alpha = contentAlpha;
         
         if (event.message.isDelayed) {
             [indexPathsOfVisibleCellsWithRelativeTimesToRefresh addObject:indexPath];


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-750

Regression from https://github.com/Zingle/ios-sdk/pull/116

![12338445_938045769617316_1820680325_n](https://user-images.githubusercontent.com/1328743/32117590-d03d32a4-bb03-11e7-9a3f-070875f46c7a.jpg)
