### PR TITLE
IOS-506: Prevent editing Facebook/etc. channel values

### DIFF
--- a/Pod/Classes/Models/ZNGChannelType.h
+++ b/Pod/Classes/Models/ZNGChannelType.h
@@ -18,6 +18,8 @@
 @property(nonatomic) BOOL allowCommunications;
 @property(nonatomic) BOOL isGlobal;
 
+- (BOOL) valueIsHumanReadable;
+
 - (BOOL) isPhoneNumberType;
 - (BOOL) isEmailType;
 

--- a/Pod/Classes/Models/ZNGChannelType.m
+++ b/Pod/Classes/Models/ZNGChannelType.m
@@ -43,6 +43,16 @@ static NSString * const ZNGChannelTypeClassUserDefined = @"UserDefinedChannel";
              };
 }
 
+/**
+ *  In a sane world, the API would tell us if a channel type should be readable/editable by a human being.
+ *  We do not live in such a world, so we will assume that only phone numbers and email addresses are human editable.
+ */
+- (BOOL) valueIsHumanReadable
+{
+    // TODO: Replace this method once the API provides an alternative to checking vs. channel type class string.
+    return (([self isPhoneNumberType]) || ([self isEmailType]));
+}
+
 - (BOOL) isPhoneNumberType
 {
     return [self.typeClass isEqualToString:ZNGChannelTypeClassPhoneNumber];

--- a/Pod/Classes/UI/Controllers/ZNGContactEditViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGContactEditViewController.m
@@ -627,7 +627,8 @@ static NSString * const SelectLabelSegueIdentifier = @"selectLabel";
                 channel = phoneNumberChannels[indexPath.row - [nonPhoneNumberChannels count]];
             }
             
-            BOOL locked = [self.contact editingChannelIsLocked:channel];
+            BOOL channelTypeIsHumanReadable = [channel.channelType valueIsHumanReadable];
+            BOOL locked = ((!channelTypeIsHumanReadable) || ([self.contact editingChannelIsLocked:channel]));
             
             if ([channel isPhoneNumber]) {
                 ZNGContactPhoneNumberTableViewCell * cell = [tableView dequeueReusableCellWithIdentifier:@"phone" forIndexPath:indexPath];


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-506

Only channel values of `typeClass` `PhoneNumber` or `EmailAddress` will be editable in the contact edit UI.

![4f46a4a05702635144c8aa0892e27197](https://user-images.githubusercontent.com/1328743/32120058-09bcefbc-bb0c-11e7-9e27-f3a244e672eb.jpg)
