### PR TITLE
Tiny warning go squish

### DIFF
--- a/Pod/Classes/UI/ViewModels/Events/ZNGConversation.m
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGConversation.m
@@ -936,7 +936,7 @@ static const CGFloat imageAttachmentMaxHeight = 800.0;
     
     // Set a timer to remove him after some time.
     // Use weak timers if they are available.
-    if ([NSTimer respondsToSelector:@selector(scheduledTimerWithTimeInterval:repeats:block:)]) {
+    if (@available(iOS 10.0, *)) {
         __weak ZNGConversation * weakSelf = self;
         newTimer = [NSTimer scheduledTimerWithTimeInterval:userTypingIndicatorLifetime repeats:NO block:^(NSTimer * _Nonnull timer) {
             [weakSelf _removeRespondingUser:pendingResponse];


### PR DESCRIPTION
Yes, Xcode, I know that selector is not available in iOS 9.  That's why I checked if the selector was available before I called it.

Have it your way.

![images](https://user-images.githubusercontent.com/1328743/32462582-c5ba00d0-c2ee-11e7-8af3-77a0b82aae5d.jpg)
