### PR TITLE
IOS-757: Fixed date custom field saving

### DIFF
--- a/Pod/Classes/UI/Views/Contact Editing/ZNGContactCustomFieldTableViewCell.m
+++ b/Pod/Classes/UI/Views/Contact Editing/ZNGContactCustomFieldTableViewCell.m
@@ -459,10 +459,18 @@ static const int zngLogLevel = ZNGLogLevelWarning;
 - (void) applyChangesIfFirstResponder
 {
     if (self.textField.isFirstResponder) {
+        // Any picker type custom field will save its own value every time a value is selected in the picker.
+        // Booleans will need to be sanitized to "true" or "false" from other truthy values (yes/no)
         if ([self.customFieldValue.customField.dataType isEqualToString:ZNGContactFieldDataTypeBool]) {
             self.customFieldValue.value = ([self.customFieldValue.value boolValue]) ? @"true" : @"false";
         } else {
-            self.customFieldValue.value = self.textField.text;
+            // Non-picker, non-bool fields will need to be saved if they are mid-edit.
+            UIView * picker = self.textField.inputView;
+            BOOL pickerExists = (([picker isKindOfClass:[UIDatePicker class]]) || ([picker isKindOfClass:[UIPickerView class]]));
+            
+            if (!pickerExists) {
+                self.customFieldValue.value = self.textField.text;
+            }
         }
     }
 }


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-757

On physical iOS 11 devices, date custom fields were being set to the human readable string like `05/07/1985` instead of the expected epoch timestamp.  How silly.

![dance](http://s2.quickmeme.com/img/d8/d8c5ea4491519f2d728739d87f7db962f9908d6b9c95955f9e2cec0cc71aaee8.jpg)