### PR TITLE
IOS-757: Silly Russian date fix

### DIFF
--- a/Pod/Classes/UI/Views/Contact Editing/ZNGContactCustomFieldTableViewCell.m
+++ b/Pod/Classes/UI/Views/Contact Editing/ZNGContactCustomFieldTableViewCell.m
@@ -166,6 +166,7 @@ static const int zngLogLevel = ZNGLogLevelWarning;
         self.textField.clearButtonMode = UITextFieldViewModeAlways;
         datePicker = [[UIDatePicker alloc] init];
         datePicker.datePickerMode = UIDatePickerModeDate;
+        datePicker.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
         datePicker.timeZone = [NSTimeZone timeZoneWithName:@"UTC"];
         [datePicker addTarget:self action:@selector(datePickerSelectedDate:) forControlEvents:UIControlEventValueChanged];
         self.textField.inputView = datePicker;


### PR DESCRIPTION
Apparently Russian localization settings do not play well with using UTC as a time zone.  How very Пиндос of me to think that it would.

![amazing](https://img.wonkette.com/wp-content/uploads/2014/04/dinosaddle.jpg)