### PR TITLE
IOS-758: More tolerant Hotsos API URL handling

### DIFF
--- a/Pod/Classes/Clients/ZNGHotsosClient.m
+++ b/Pod/Classes/Clients/ZNGHotsosClient.m
@@ -44,10 +44,30 @@ static const int zngLogLevel = ZNGLogLevelDebug;
     return self;
 }
 
+/**
+ *  Ensures that the hotsosHostName includes https:// and not http:// nor nothing at all
+ */
+- (NSString *) hotsosURLAsSSL
+{
+    NSURLComponents * components = [NSURLComponents componentsWithString:self.service.hotsosHostName];
+    
+    if (components == nil) {
+        return nil;
+    }
+    
+    if (components.host == nil) {
+        components.host = components.path;
+        components.path = nil;
+    }
+    
+    components.scheme = @"https";
+    return components.string;
+}
+
 - (NSString *) hotsosIssuePathForTerm:(NSString *)term
 {
     NSString * fuzzyTerm = [[NSString stringWithFormat:@"%%%@%%", term] stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
-    return [NSString stringWithFormat:@"https://%@/api/service.svc/rest/GetIssueCollection?nameLike=%@", [self.service hotsosHostName], fuzzyTerm];
+    return [NSString stringWithFormat:@"%@/api/service.svc/rest/GetIssueCollection?nameLike=%@", [self hotsosURLAsSSL], fuzzyTerm];
 }
 
 - (void) getIssuesLike:(NSString *)term completion:(void (^)(NSArray<NSString *> * _Nullable matchingIssueNames, NSError * _Nullable error))completion;


### PR DESCRIPTION
The API used to just send us a host name and path.  Now it sometimes enjoys sending http:// for a host name where we would like to use https:// anyway.  You can't tell us what to do, server.

![giphy](https://user-images.githubusercontent.com/1328743/33460298-5f5844c6-d5e2-11e7-8793-63553a5452e6.gif)
