### PR TITLE
IOS-767: Internet busto should not mean app busto

### DIFF
--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
@@ -347,6 +347,7 @@ NSString * const ZNGInboxDataSetSortDirectionDescending = @"desc";
                 dispatch_semaphore_signal(semaphore);
             } failure:^(ZNGError *error) {
                 ZNGLogWarn(@"Unable to fetch inbox data for page %llu: %@", (unsigned long long)page, error);
+                [self _removeLoadingPage:page];
                 dispatch_semaphore_signal(semaphore);
             }];
             


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-767

Fixed a bug that caused an temporary internet connectivity problem to forever break inbox refreshing.

![mailbox](https://user-images.githubusercontent.com/1328743/34502165-200c8ce2-efc7-11e7-94c4-705bf93bab63.gif)
