### PR TITLE
Admins see all teams

### DIFF
--- a/Pod/Classes/Models/ZNGUser.h
+++ b/Pod/Classes/Models/ZNGUser.h
@@ -10,6 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class ZNGService;
 @class ZNGUserAuthorization;
 
 @interface ZNGUser : MTLModel<MTLJSONSerializing>
@@ -22,10 +23,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong, nullable) NSString* title;
 @property(nonatomic, strong, nullable) NSArray* serviceIds;
 @property(nonatomic, strong, nullable) NSURL * avatarUri;
+@property(nonatomic, strong, nullable) NSDictionary<NSString *, NSArray<NSString *> *> * servicePrivileges;
 
 - (NSString * _Nullable) fullName;
 
-+ (instancetype) userFromUserAuthorization:(ZNGUserAuthorization *)auth;
+- (BOOL) canMonitorAllTeamsOnService:(ZNGService *)service;
+
+- (NSArray<NSString *> * _Nullable) privilegesForService:(ZNGService *)service;
+
 + (instancetype) userFromSocketData:(NSDictionary *)data;
 
 NS_ASSUME_NONNULL_END

--- a/Pod/Classes/Models/ZNGUser.m
+++ b/Pod/Classes/Models/ZNGUser.m
@@ -7,7 +7,10 @@
 //
 
 #import "ZNGUser.h"
+#import "ZNGService.h"
 #import "ZNGUserAuthorization.h"
+
+static NSString * const ZNGUserPrivilegeMonitorTeams = @"monitor_teams";
 
 @implementation ZNGUser
 
@@ -21,7 +24,8 @@
              @"lastName" : @"last_name",
              @"title" : @"title",
              @"serviceIds" : @"service_ids",
-             @"avatarUri" : @"avatar_uri"
+             @"avatarUri" : @"avatar_uri",
+             NSStringFromSelector(@selector(servicePrivileges)): @"service_privileges",
              };
 }
 
@@ -70,19 +74,18 @@
     return nil;
 }
 
-+ (instancetype) userFromUserAuthorization:(ZNGUserAuthorization *)auth
+- (BOOL) canMonitorAllTeamsOnService:(ZNGService *)service;
 {
-    ZNGUser * user = [[self alloc] init];
+    return [[self privilegesForService:service] containsObject:ZNGUserPrivilegeMonitorTeams];
+}
+
+- (NSArray<NSString *> * _Nullable) privilegesForService:(ZNGService *)service
+{
+    if (service.serviceId == nil) {
+        return nil;
+    }
     
-    user.firstName = auth.firstName;
-    user.lastName = auth.lastName;
-    user.userId = auth.userId;
-    user.email = auth.email;
-    user.title = auth.title;
-    user.serviceIds = auth.serviceIds;
-    user.avatarUri = auth.avatarUri;
-    
-    return user;
+    return self.servicePrivileges[service.serviceId];
 }
 
 + (instancetype) userFromSocketData:(NSDictionary *)data

--- a/Pod/Classes/Models/ZNGUserAuthorization.h
+++ b/Pod/Classes/Models/ZNGUserAuthorization.h
@@ -7,19 +7,11 @@
 //
 
 #import <Mantle/Mantle.h>
+#import "ZNGUser.h"
 
-@interface ZNGUserAuthorization : MTLModel<MTLJSONSerializing>
+@interface ZNGUserAuthorization : ZNGUser
 
 @property (nonatomic, strong, nullable) NSString * authorizationClass;
-@property (nonatomic, strong, nullable) NSString * userId;
-@property (nonatomic, strong, nullable) NSString * username;
-@property (nonatomic, strong, nullable) NSString * email;
-@property (nonatomic, strong, nullable) NSString * firstName;
-@property (nonatomic, strong, nullable) NSString * lastName;
-@property (nonatomic, strong, nullable) NSString * title;
-@property (nonatomic, strong, nullable) NSArray<NSString *> * accountIds;
-@property (nonatomic, strong, nullable) NSArray<NSString *> * serviceIds;
-@property (nonatomic, strong, nullable) NSURL * avatarUri;
 
 - (NSString * _Nullable) displayName;
 

--- a/Pod/Classes/Models/ZNGUserAuthorization.m
+++ b/Pod/Classes/Models/ZNGUserAuthorization.m
@@ -13,27 +13,14 @@
 
 + (NSDictionary*)JSONKeyPathsByPropertyKey
 {
-    return @{
-             @"authorizationClass" : @"authorization_class",
-             NSStringFromSelector(@selector(userId)) : @"id",
-             @"email" : @"email",
-             @"firstName" : @"first_name",
-             @"lastName" : @"last_name",
-             @"title" : @"title",
-             NSStringFromSelector(@selector(accountIds)): @"account_uuids",
-             NSStringFromSelector(@selector(serviceIds)): @"service_uuids",
-             NSStringFromSelector(@selector(avatarUri)): @"avatar_uri",
-             };
-}
-
-+ (NSValueTransformer *) avatarUriJSONTransformer
-{
-    return [NSValueTransformer valueTransformerForName:MTLURLValueTransformerName];
+    return [[super JSONKeyPathsByPropertyKey] mtl_dictionaryByAddingEntriesFromDictionary:@{
+                                                                                            NSStringFromSelector(@selector(authorizationClass)): @"authorization_class",
+                                                                                            }];
 }
 
 - (NSString *)displayName
 {
-    return [[ZNGUser userFromUserAuthorization:self] fullName];
+    return [super fullName];
 }
 
 @end

--- a/Pod/Classes/UI/ViewModels/Events/ZNGConversation.m
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGConversation.m
@@ -21,6 +21,7 @@
 #import "UIImage+animatedGIF.h"
 #import "NSData+ImageType.h"
 #import "ZNGPendingResponseOrNote.h"
+#import "ZNGUserAuthorization.h"
 
 static const int zngLogLevel = ZNGLogLevelVerbose;
 
@@ -849,7 +850,7 @@ static const CGFloat imageAttachmentMaxHeight = 800.0;
 
     if ([self.messageClient.session isKindOfClass:[ZingleAccountSession class]]) {
         ZingleAccountSession * accountSession = (ZingleAccountSession *)self.messageClient.session;
-        message.triggeredByUser = [ZNGUser userFromUserAuthorization:accountSession.userAuthorization];
+        message.triggeredByUser = accountSession.userAuthorization;
     }
     
     if ([newMessage.outgoingImageAttachments count] > 0) {

--- a/Pod/Classes/UI/ViewModels/Events/ZNGConversationServiceToContact.m
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGConversationServiceToContact.m
@@ -16,6 +16,7 @@
 #import "ZNGMessageForwardingRequest.h"
 #import "ZNGSocketClient.h"
 #import "ZingleAccountSession.h"
+#import "ZNGUserAuthorization.h"
 
 static const int zngLogLevel = ZNGLogLevelWarning;
 
@@ -365,7 +366,7 @@ static NSString * const ChannelsKVOPath = @"contact.channels";
 
 - (void) addAvatarToSendingEvent:(ZNGEvent *)event
 {
-    event.triggeredByUser = [ZNGUser userFromUserAuthorization:self.session.userAuthorization];
+    event.triggeredByUser = self.session.userAuthorization;
 }
 
 - (void) triggerAutomation:(ZNGAutomation *)automation completion:(void (^)(BOOL success))completion

--- a/Pod/Classes/ZingleAccountSession.m
+++ b/Pod/Classes/ZingleAccountSession.m
@@ -567,7 +567,10 @@ NSString * const ZingleUserChangedDetailedEventsPreferenceNotification = @"Zingl
         return @[];
     }
     
-    // TODO: Return all teams if the user is an admin.  We do not yet have that data.
+    // Return all teams if this user has sufficient privilege
+    if ([self.userAuthorization canMonitorAllTeamsOnService:self.service]) {
+        return self.service.teams;
+    }
     
     NSPredicate * oneOfMyTeams = [NSPredicate predicateWithFormat:@"%@ IN userIds", self.userAuthorization.userId];
     return [self.service.teams filteredArrayUsingPredicate:oneOfMyTeams];


### PR DESCRIPTION
- Added parsing of user privilege data that is now available in the API
- Users with the `monitor_teams` privilege will now see all teams in the left menu
- Changed the mostly redundant `ZNGUserAuthorization` class to be a simple subclass of `ZNGUser` with one additional field

![server1](https://user-images.githubusercontent.com/1328743/35128676-b6c35722-fc6c-11e7-9980-620415892db3.gif)
