### PR TITLE
Remove the "assign" option from services with no assignment

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -897,10 +897,12 @@ enum ZNGConversationSections
     
     NSString * uiType = @"ellipsis menu";
     
-    UIAlertAction * assign = [UIAlertAction actionWithTitle:@"Assign" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-        [self performSegueWithIdentifier:@"assign" sender:self];
-    }];
-    [actions addObject:assign];
+    if ([self.conversation.session.service allowsAssignment]) {
+        UIAlertAction * assign = [UIAlertAction actionWithTitle:@"Assign" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+            [self performSegueWithIdentifier:@"assign" sender:self];
+        }];
+        [actions addObject:assign];
+    }
     
     UIAlertAction * editContact = [UIAlertAction actionWithTitle:@"View / edit contact" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
         [self pressedEditContact];


### PR DESCRIPTION
This one place was missed when showing/hiding assignment options.  Oops.

![you_can t_see_me _no_one_can_see_me](https://user-images.githubusercontent.com/1328743/36287954-178285e0-126d-11e8-9404-a99dd566bc42.gif)
