### PR TITLE
One more implicit self capture fix

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -457,9 +457,9 @@ enum ZNGConversationSections
     titleLabel.attributedText = title;
     
     void (^sizeAndPlaceTitle)(void) = ^{
-        CGSize size = [titleLabel intrinsicContentSize];
-        titleLabel.frame = CGRectMake(0.0, 0.0, size.width, size.height);
-        self.navigationItem.titleView = titleLabel;
+        CGSize size = [self->titleLabel intrinsicContentSize];
+        self->titleLabel.frame = CGRectMake(0.0, 0.0, size.width, size.height);
+        self.navigationItem.titleView = self->titleLabel;
     };
     
     if (deferUpdateToNextRunLoopCycle) {


### PR DESCRIPTION
Because everyone loves `->`

![right-down-arrow-green](https://user-images.githubusercontent.com/1328743/36390985-7da3690e-1559-11e8-861e-632b0b2a1067.gif)
