### PR TITLE
IOS-805: Fix assignment event descriptions for automation assignments

### DIFF
--- a/Pod/Classes/Models/ZNGEvent.m
+++ b/Pod/Classes/Models/ZNGEvent.m
@@ -285,7 +285,7 @@ NSString * const ZNGEventTypeAssignmentChange = @"assignment_changed";
         
         // Add the user info if available.
         // It's arguable that this appending should be added to every single return value instead of just assignment.
-        if (self.triggeredByUser != nil) {
+        if (self.triggeredByUser.userId != nil) {
             [description appendFormat:@" by %@", [self.triggeredByUser fullName]];
         }
         

--- a/Pod/Classes/Models/ZNGEvent.m
+++ b/Pod/Classes/Models/ZNGEvent.m
@@ -287,6 +287,8 @@ NSString * const ZNGEventTypeAssignmentChange = @"assignment_changed";
         // It's arguable that this appending should be added to every single return value instead of just assignment.
         if (self.triggeredByUser.userId != nil) {
             [description appendFormat:@" by %@", [self.triggeredByUser fullName]];
+        } else if (self.automation.automationId != nil) {
+            [description appendFormat:@" by \"%@\"", self.automation.displayName];
         }
         
         return description;


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-805

This also fixes "by (null) being shown for every single automation event that lacked a triggeredByUser name.

![ledbadge_blue](https://user-images.githubusercontent.com/1328743/36689664-ef641af8-1ae4-11e8-9fb9-aa7f27d4339f.gif)
