### PR TITLE
IOS-798: Require full team/user data before session is usable

### DIFF
--- a/Example/Tests/TestAccountSession.m
+++ b/Example/Tests/TestAccountSession.m
@@ -113,6 +113,7 @@
 - (void) testSingleAccountSingleServiceLogin
 {
     ZingleAccountSession * session = [ZingleSDK accountSessionWithToken:@"token" key:@"key"];
+    session.users = @[];
     
     // Set the HTTP client to nil to prevent reaching out through the internet tubes if we forget to stub something
 #pragma clang diagnostic push
@@ -157,6 +158,7 @@
 - (void) testAccountChooserBlock
 {
     ZingleAccountSession * session = [ZingleSDK accountSessionWithToken:@"token" key:@"key"];
+    session.users = @[];
     
     // Set the HTTP client to nil to prevent reaching out through the internet tubes if we forget to stub something
 #pragma clang diagnostic push
@@ -187,6 +189,7 @@
 - (void) testServiceChooserBlock
 {
     ZingleAccountSession * session = [ZingleSDK accountSessionWithToken:@"token" key:@"key"];
+    session.users = @[];
     
     // Set the HTTP client to nil to prevent reaching out through the internet tubes if we forget to stub something
 #pragma clang diagnostic push
@@ -232,6 +235,7 @@
 - (void) testUserAuthorizationAvailableImmediately
 {
     ZingleAccountSession * session = [ZingleSDK accountSessionWithToken:@"token" key:@"key"];
+    session.users = @[];
     
     // Set the HTTP client to nil to prevent reaching out through the internet tubes if we forget to stub something
 #pragma clang diagnostic push
@@ -270,6 +274,7 @@
 - (void) testRegisteredForPushNotifications
 {
     ZingleAccountSession * session = [ZingleSDK accountSessionWithToken:@"token" key:@"key"];
+    session.users = @[];
     
     // Set the HTTP client to nil to prevent reaching out through the internet tubes if we forget to stub something
 #pragma clang diagnostic push
@@ -317,6 +322,7 @@
 - (void) testLogoutRemovesPushNotificationSubscription
 {
     ZingleAccountSession * session = [ZingleSDK accountSessionWithToken:@"token" key:@"key"];
+    session.users = @[];
     
     // Set the HTTP client to nil to prevent reaching out through the internet tubes if we forget to stub something
 #pragma clang diagnostic push

--- a/Pod/Classes/Clients/ZNGSocketClient.m
+++ b/Pod/Classes/Clients/ZNGSocketClient.m
@@ -19,7 +19,7 @@
 @import SocketIO;
 
 #if DEBUG
-static const int zngLogLevel = ZNGLogLevelInfo;
+static const int zngLogLevel = ZNGLogLevelDebug;
 #else
 static const int zngLogLevel = ZNGLogLevelWarning;
 #endif

--- a/Pod/Classes/Clients/ZNGSocketClient.m
+++ b/Pod/Classes/Clients/ZNGSocketClient.m
@@ -391,7 +391,7 @@ static const int zngLogLevel = ZNGLogLevelWarning;
     
     ZingleAccountSession * session = (ZingleAccountSession *)self.session;
     
-    NSMutableArray<ZNGUser *> * users = [[NSMutableArray alloc] initWithCapacity:[data count]];
+    NSMutableArray<ZNGUser *> * users = [[NSMutableArray alloc] init];
     
     for (NSDictionary * userDictionary in [data firstObject]) {
         [users addObject:[ZNGUser userFromSocketData:userDictionary]];

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.h
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.h
@@ -95,6 +95,6 @@
  *  Confirms that an inbox data set made with this builder can be used with the provided session.
  *  Fails if a group/label/user/team specified in the data set is not present in the provided session.
  */
-- (BOOL) builderCanBeUsedForSession:(ZingleAccountSession * _Nonnull)session;
+- (BOOL) canBeUsedForSession:(ZingleAccountSession * _Nonnull)session;
 
 @end

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.h
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.h
@@ -10,6 +10,7 @@
 #import <Mantle/Mantle.h>
 #import "ZNGInboxDataSet.h"
 
+@class ZingleAccountSession;
 @class ZNGContactClient;
 
 @interface ZNGContactDataSetBuilder : MTLModel <MTLJSONSerializing>
@@ -89,5 +90,11 @@
 @property (nonatomic, strong, nonnull) ZNGContactClient * contactClient;
 
 - (nonnull ZNGInboxDataSet *)build;
+
+/**
+ *  Confirms that an inbox data set made with this builder can be used with the provided session.
+ *  Fails if a group/label/user/team specified in the data set is not present in the provided session.
+ */
+- (BOOL) builderCanBeUsedForSession:(ZingleAccountSession * _Nonnull)session;
 
 @end

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.m
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.m
@@ -8,6 +8,9 @@
 
 #import "ZNGContactDataSetBuilder.h"
 #import "ZNGInboxDataSet.h"
+#import "ZingleAccountSession.h"
+#import "ZNGLabel.h"
+#import "ZNGContactGroup.h"
 
 @implementation ZNGContactDataSetBuilder
 
@@ -57,6 +60,57 @@
              NSStringFromSelector(@selector(searchText)): NSStringFromSelector(@selector(searchText)),
              NSStringFromSelector(@selector(searchMessageBodies)): NSStringFromSelector(@selector(searchMessageBodies)),
              };
+}
+
+- (BOOL) builderCanBeUsedForSession:(ZingleAccountSession *)session
+{
+    if (self.unassigned) {
+        if (![session.service allowsAssignment]) {
+            return NO;
+        }
+    }
+    
+    if ([self.assignedUserId length] > 0) {
+        if (![session.service allowsAssignment]) {
+            return NO;
+        }
+        
+        if ([session userWithId:self.assignedUserId] == nil) {
+            return NO;
+        }
+    }
+    
+    if ([self.assignedTeamId length] > 0) {
+        if (![session.service allowsTeamAssignment]) {
+            return NO;
+        }
+        
+        if ([session.service teamWithId:self.assignedTeamId] == nil) {
+            return NO;
+        }
+    }
+    
+    for (NSString * labelId in self.labelIds) {
+        NSUInteger matchingLabelIndex = [session.service.contactLabels indexOfObjectPassingTest:^BOOL(ZNGLabel * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+            return ([obj.labelId isEqualToString:labelId]);
+        }];
+        
+        if (matchingLabelIndex == NSNotFound) {
+            return NO;
+        }
+    }
+    
+    for (NSString * groupId in self.groupIds) {
+        NSUInteger matchingGroupIndex = [session.service.contactGroups indexOfObjectPassingTest:^BOOL(ZNGContactGroup * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+            return ([obj.groupId isEqualToString:groupId]);
+        }];
+        
+        if (matchingGroupIndex == NSNotFound) {
+            return NO;
+        }
+    }
+    
+    return YES;
 }
 
 @end

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.m
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.m
@@ -62,7 +62,7 @@
              };
 }
 
-- (BOOL) builderCanBeUsedForSession:(ZingleAccountSession *)session
+- (BOOL) canBeUsedForSession:(ZingleAccountSession *)session
 {
     if (self.unassigned) {
         if (![session.service allowsAssignment]) {

--- a/Pod/Classes/ZingleAccountSession.m
+++ b/Pod/Classes/ZingleAccountSession.m
@@ -452,10 +452,14 @@ NSString * const ZingleConversationNotificationContactIdKey = @"contactId";
         [self synchronouslyRetrieveUserData];
         [self synchronouslyRetrieveTeamsData];
         
-        dispatch_semaphore_wait(self->initialUserDataSemaphore, tenSecondTimeout);
+        long waitResult = dispatch_semaphore_wait(self->initialUserDataSemaphore, tenSecondTimeout);
         
-        NSTimeInterval duration = [[NSDate date] timeIntervalSinceDate:before];
-        ZNGLogDebug(@"Waited %.2f seconds for user/team data on login", (float)duration);
+        if (waitResult == 0) {
+            NSTimeInterval duration = [[NSDate date] timeIntervalSinceDate:before];
+            ZNGLogDebug(@"Waited %.2f seconds for user/team data on login", (float)duration);
+        } else {
+            ZNGLogError(@"Timed out waiting for user and team data on initial login.  Assignment functionality may be broken until this arrives.");
+        }
         
         dispatch_async(dispatch_get_main_queue(), ^{
             self.available = YES;

--- a/Pod/Classes/ZingleAccountSession.m
+++ b/Pod/Classes/ZingleAccountSession.m
@@ -35,7 +35,7 @@
 
 static NSString * const kSocketConnectedKeyPath = @"socketClient.connected";
 
-static const int zngLogLevel = ZNGLogLevelInfo;
+static const int zngLogLevel = ZNGLogLevelDebug;
 
 NSString * const ZingleUserChangedDetailedEventsPreferenceNotification = @"ZingleUserChangedDetailedEventsPreferenceNotification";
 NSString * const ZingleConversationDataArrivedNotification = @"ZingleConversationDataArrivedNotification";
@@ -56,6 +56,8 @@ NSString * const ZingleConversationNotificationContactIdKey = @"contactId";
     ZNGService * _service;
     NSDate * serviceSetDate;
     
+    dispatch_semaphore_t initialUserDataSemaphore;
+    
     NSMutableSet<NSString *> * allLoadedConversationIds;    // List of all conversation IDs ever seen.  Conversations corresponding to these IDs may or may not exist in conversationCache.
     
     UIStoryboard * _storyboard;
@@ -67,6 +69,7 @@ NSString * const ZingleConversationNotificationContactIdKey = @"contactId";
     
     if (self != nil) {
         contactClientSemaphore = dispatch_semaphore_create(0);
+        initialUserDataSemaphore = dispatch_semaphore_create(0);
         
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(notifyShowDetailedEventsPreferenceChanged:) name:ZingleUserChangedDetailedEventsPreferenceNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(notifyBecameActive:) name:UIApplicationDidBecomeActiveNotification object:nil];
@@ -436,16 +439,28 @@ NSString * const ZingleConversationNotificationContactIdKey = @"contactId";
     // We now have both an account and a service selected.
     
     [self initializeAllClients];
-    [self retrieveSupplementalV2ApiData];
+    
+    if (self.users != nil) {
+        // We already have user data.  Go ahead and signal the semaphore so it does not block us below.
+        dispatch_semaphore_signal(initialUserDataSemaphore);
+    }
     
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [self synchronouslyRetrieveUserData];
+        [self synchronouslyRetrieveTeamsData];
+        
+        NSDate * before = [NSDate date];
+        
+        dispatch_time_t fiveSecondTimeout = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC));
+        dispatch_semaphore_wait(self->initialUserDataSemaphore, fiveSecondTimeout);
+        
+        NSTimeInterval duration = [[NSDate date] timeIntervalSinceDate:before];
+        ZNGLogDebug(@"Waited %.2f seconds for user data on login", (float)duration);
         
         dispatch_async(dispatch_get_main_queue(), ^{
             self.available = YES;
         });
     });
-    
 }
 
 - (void) initializeAllClients
@@ -482,18 +497,35 @@ NSString * const ZingleConversationNotificationContactIdKey = @"contactId";
     NSSortDescriptor * firstName = [NSSortDescriptor sortDescriptorWithKey:@"fullName" ascending:YES selector:@selector(localizedCaseInsensitiveCompare:)];
     
     _users = [users sortedArrayUsingDescriptors:@[activeStatus, firstName]];
+    dispatch_semaphore_signal(initialUserDataSemaphore);
 }
 
 /**
  *  Go acquire some data that the v1 API does not supply, namely numeric IDs that the socket server throws at us.
  */
-- (void) retrieveSupplementalV2ApiData
+- (void) synchronouslyRetrieveTeamsData
 {
+    if ([[NSThread currentThread] isMainThread]) {
+        ZNGLogError(@"%s called on main thread.  Returning without fetching user data to prevent deadlock.", __PRETTY_FUNCTION__);
+        return;
+    }
+    
+    if (self.teamClient == nil) {
+        return;
+    }
+    
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    
     [self.teamClient teamListWithSuccess:^(NSArray<ZNGTeamV2 *> * _Nullable teams) {
         [self.inboxStatistician updateWithV2TeamsData:teams];
+        dispatch_semaphore_signal(semaphore);
     } failure:^(ZNGError * _Nullable error) {
         ZNGLogError(@"Unable to retrieve team IDs from v2 API.");
+        dispatch_semaphore_signal(semaphore);
     }];
+    
+    dispatch_time_t tenSecondTimeout = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10.0 * NSEC_PER_SEC));
+    dispatch_semaphore_wait(semaphore, tenSecondTimeout);
 }
 
 - (void) updateUserData
@@ -531,11 +563,6 @@ NSString * const ZingleConversationNotificationContactIdKey = @"contactId";
     
     dispatch_time_t tenSecondTimeout = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10.0 * NSEC_PER_SEC));
     dispatch_semaphore_wait(semaphore, tenSecondTimeout);
-    
-    if ([self.userAuthorization.userId length] == 0) {
-        // We failed to get the user ID; we cannot get the user object below.
-        return;
-    }
 }
 
 - (void) notifyShowDetailedEventsPreferenceChanged:(NSNotification *)notification

--- a/Pod/Classes/ZingleAccountSession.m
+++ b/Pod/Classes/ZingleAccountSession.m
@@ -446,16 +446,16 @@ NSString * const ZingleConversationNotificationContactIdKey = @"contactId";
     }
     
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        NSDate * before = [NSDate date];
+        dispatch_time_t tenSecondTimeout = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10.0 * NSEC_PER_SEC));
+
         [self synchronouslyRetrieveUserData];
         [self synchronouslyRetrieveTeamsData];
         
-        NSDate * before = [NSDate date];
-        
-        dispatch_time_t fiveSecondTimeout = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC));
-        dispatch_semaphore_wait(self->initialUserDataSemaphore, fiveSecondTimeout);
+        dispatch_semaphore_wait(self->initialUserDataSemaphore, tenSecondTimeout);
         
         NSTimeInterval duration = [[NSDate date] timeIntervalSinceDate:before];
-        ZNGLogDebug(@"Waited %.2f seconds for user data on login", (float)duration);
+        ZNGLogDebug(@"Waited %.2f seconds for user/team data on login", (float)duration);
         
         dispatch_async(dispatch_get_main_queue(), ^{
             self.available = YES;


### PR DESCRIPTION
- Sessions are no longer marked active before they have full team/user data
- Added a method in `ZNGInboxDataSetBuilder` to check the validity of an inbox filter in a specific service

Facilitates https://zingle.atlassian.net/browse/IOS-798 through other changes in the business app.

![i chzbgr](https://user-images.githubusercontent.com/1328743/36749173-d29106f0-1bae-11e8-9d4c-372721ab8561.gif)
