### PR TITLE
IOS-811: Added a flag to edit contact to avoid custom transitions

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGContactEditViewController.h
+++ b/Pod/Classes/UI/Controllers/ZNGContactEditViewController.h
@@ -47,6 +47,8 @@
 @property (nonatomic, strong) ZNGService * service;
 @property (nonatomic, copy) ZNGContact * contact;
 
+@property (nonatomic, assign) BOOL useDefaultTransition;
+
 @property (nonatomic, weak) id <ZNGContactEditDelegate> delegate;
 
 - (IBAction)pressedCancel:(id)sender;

--- a/Pod/Classes/UI/Controllers/ZNGContactEditViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGContactEditViewController.m
@@ -86,7 +86,7 @@ static NSString * const AssignSegueIdentifier = @"assign";
     [super viewDidLoad];
     
     // If someone else has specified their own transitioningDelegate, we will relinquish control of our transitioning to them.
-    if (self.transitioningDelegate == nil) {
+    if ((self.transitioningDelegate == nil) && (!self.useDefaultTransition)) {
         self.transitioningDelegate = self;
     }
     


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-811

The transition from the contact view was the bad kind of goofy.

![goofy_ frankenstein_form _ art](https://user-images.githubusercontent.com/1328743/36763148-8cd62cc6-1bdb-11e8-977a-4d81cfafb4e0.png)
