### PR TITLE
Added a method to compare two types of inbox data while ignoring open/closed

### DIFF
--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.h
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.h
@@ -149,6 +149,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (ZNGContactDataSetBuilder *) builder;
 
+#pragma mark - Comparison
+
+/**
+ *  Tests whether two data sets are equal when ignoring open/closed status.
+ */
+- (BOOL) isEqualDisregardingOpenStatus:(ZNGInboxDataSet *)object;
+
 #pragma mark - Actions
 /**
  *  Refreshes the first page of data.  This data will be merged into the contacts array without resetting the loadingInitialData property.

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
@@ -302,6 +302,16 @@ NSString * const ZNGInboxDataSetSortDirectionDescending = @"desc";
     return [[self parameters] isEqualToDictionary:[object parameters]];
 }
 
+- (BOOL) isEqualDisregardingOpenStatus:(ZNGInboxDataSet *)object
+{
+    NSMutableDictionary * myParameters = [[self parameters] mutableCopy];
+    NSMutableDictionary * otherParameters = [[object parameters] mutableCopy];
+    [myParameters removeObjectForKey:ParameterKeyIsClosed];
+    [otherParameters removeObjectForKey:ParameterKeyIsClosed];
+    
+    return [myParameters isEqualToDictionary:otherParameters];
+}
+
 #pragma mark - Loading data
 - (void) refresh
 {


### PR DESCRIPTION
This can be used to determine if an inbox data change indicates switching between open/close in the same type of inbox or if it represents an entirely new type of inbox (team A vs. unassigned, etc.).

![tenor](https://user-images.githubusercontent.com/1328743/36817517-46f9046a-1c96-11e8-8580-c3fdb5658857.gif)
