### PR TITLE
IOS-817: Fixed a crash when sending group messages

### DIFF
--- a/Pod/Classes/Clients/ZNGSocketClient.m
+++ b/Pod/Classes/Clients/ZNGSocketClient.m
@@ -334,7 +334,7 @@ static const int zngLogLevel = ZNGLogLevelWarning;
 #pragma mark - Sockety goodness
 - (void) socketEvent:(SocketAnyEvent *)event
 {
-    ZNGLogDebug(@"Received socket event of type %@", event.event);
+    ZNGLogDebug(@"%p received socket event of type %@", self, event.event);
     ZNGLogVerbose(@"%@", event);
 }
 

--- a/Pod/Classes/Clients/ZNGSocketClient.m
+++ b/Pod/Classes/Clients/ZNGSocketClient.m
@@ -380,7 +380,7 @@ static const int zngLogLevel = ZNGLogLevelWarning;
 {
     NSDictionary * feedData = [data firstObject];
     NSDictionary * contact = feedData[@"contact"];
-    NSString * feedId = contact[@"uuid"];
+    NSString * feedId = ([contact isKindOfClass:[NSDictionary class]]) ? contact[@"uuid"] : nil;
     
     if ([feedId length] > 0) {
         NSDictionary * userInfo = @{ZingleConversationNotificationContactIdKey: feedId};


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-817

Why does it have to be null, socket?  I thought we had a good thing going.

![tenor](https://user-images.githubusercontent.com/1328743/36818091-627307d4-1c98-11e8-83e6-74cbe7b31d84.gif)
