### PR TITLE
IOS-810: More leaky socket fixes

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGInboxViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGInboxViewController.m
@@ -690,7 +690,7 @@ static NSString * const AssignmentSwipeActionUIType = @"inbox swipe action";
         }];
     } else {
         confirmButton = [MGSwipeButton buttonWithTitle:@"Mark\nread" backgroundColor:[UIColor zng_lightBlue] callback:^BOOL(MGSwipeTableCell * _Nonnull cell) {
-            [self.data contactWasChangedLocally:contactAfterChange];
+            [weakSelf.data contactWasChangedLocally:contactAfterChange];
             
             [contact confirm];
             [[ZNGAnalytics sharedAnalytics] trackConfirmedContact:contact fromUIType:@"swipe"];


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-810

There was a retain cycle in the swipe action buttons that caused the inbox view to hang around and keep hold of a session object and its socket client forever.