### PR TITLE
IOS-815: More contact refreshing

### DIFF
--- a/Pod/Classes/UI/ViewModels/Events/ZNGConversationServiceToContact.m
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGConversationServiceToContact.m
@@ -59,6 +59,7 @@ static NSString * const ChannelsKVOPath = @"contact.channels";
         [self addObserver:self forKeyPath:ChannelsKVOPath options:NSKeyValueObservingOptionNew context:nil];
         
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(notifyContactSelfMutated:) name:ZNGContactNotificationSelfMutated object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(notifyConversationDataReceived:) name:ZingleConversationDataArrivedNotification object:nil];
     }
     
     return self;
@@ -136,6 +137,13 @@ static NSString * const ChannelsKVOPath = @"contact.channels";
 - (NSString *)remoteName
 {
     return [_contact fullName];
+}
+
+- (void) notifyConversationDataReceived:(NSNotification *)notification
+{
+    if ([self notificationRelevantToThisConversation:notification]) {
+        [self.contact updateRemotely];
+    }
 }
 
 - (BOOL) notificationRelevantToThisConversation:(NSNotification *)notification


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-815

Contact data was only being automatically refreshed if it existed within an active `ZNGInboxDataSet`.  The `ZNGContact` objects themselves will now refresh when receiving a relevant `feedUpdated` event from socket.

![funny](https://user-images.githubusercontent.com/1328743/36861767-bc5ab7b4-1d39-11e8-8821-5714b2201db9.gif)
