### PR TITLE
IOS-824: Fix locked by automation banner

### DIFF
--- a/Pod/Classes/Clients/ZNGSocketClient.m
+++ b/Pod/Classes/Clients/ZNGSocketClient.m
@@ -503,6 +503,12 @@ static const int zngLogLevel = ZNGLogLevelWarning;
     
     NSDictionary * info = [data firstObject];
     NSString * description = info[@"description"];
+    BOOL isWorkflowLock = [info[@"lockedByType"] isEqual:@"Workflow"];
+    
+    if (!isWorkflowLock) {
+        ZNGLogWarn(@"Unrecognized feedLocked type: %@", info[@"lockedByType"]);
+        return;
+    }
     
     ZingleAccountSession * accountSession = ([self.session isKindOfClass:[ZingleAccountSession class]]) ? (ZingleAccountSession *)self.session : nil;
     
@@ -511,10 +517,7 @@ static const int zngLogLevel = ZNGLogLevelWarning;
     
     BOOL lockedByMeMyselfAndI = (([meId length] > 0) && ([lockedByUserID isEqualToString:meId]));
     
-    if (lockedByMeMyselfAndI) {
-        ZNGLogVerbose(@"Received a feedLocked event, but it appears to be from our own typing.  Clearing any existing locked description.");
-        self.activeConversation.lockedDescription = nil;
-    } else {
+    if (!lockedByMeMyselfAndI) {
         ZNGLogInfo(@"Conversation was locked: %@", description);
         self.activeConversation.lockedDescription = description;
     }

--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -538,25 +538,28 @@ enum ZNGConversationSections
 
 - (NSAttributedString *) attributedTextForAutomationBanner:(NSString *)description
 {
-    NSRange inAutomationRange = [description rangeOfString:@"in automation:" options:NSCaseInsensitiveSearch];
-    
-    if ((description == nil) || (inAutomationRange.location == NSNotFound)) {
-        // This is not an 'in automation' lock string
+    if ([description length] == 0) {
         return nil;
+    }
+    
+    NSRange inZingRange = [description rangeOfString:@"in zing:" options:NSCaseInsensitiveSearch];
+    
+    if (inZingRange.location == NSNotFound) {
+        inZingRange = [description rangeOfString:@"in automation:" options:NSCaseInsensitiveSearch];
     }
     
     NSMutableAttributedString * attributedString = [[NSMutableAttributedString alloc] initWithString:description];
     
-    NSUInteger firstBoldIndex = inAutomationRange.location + inAutomationRange.length;
-    NSRange rangeToBoldify;
-    
-    // Bold the automation name
-    if (firstBoldIndex < [description length]) {
-        rangeToBoldify = NSMakeRange(firstBoldIndex, [description length] - firstBoldIndex);
+    // Bold the automation name if possible
+    if (inZingRange.location != NSNotFound) {
+        NSUInteger firstBoldIndex = inZingRange.location + inZingRange.length;
         
-        UIFont * normalFont = self.automationLabel.font ?: [UIFont systemFontOfSize:15.0];
-        UIFont * boldFont = [UIFont latoBoldFontOfSize:normalFont.pointSize];
-        [attributedString addAttribute:NSFontAttributeName value:boldFont range:rangeToBoldify];
+        if (firstBoldIndex < [description length]) {
+            NSRange rangeToBoldify = NSMakeRange(firstBoldIndex, [description length] - firstBoldIndex);
+            UIFont * normalFont = self.automationLabel.font ?: [UIFont systemFontOfSize:15.0];
+            UIFont * boldFont = [UIFont latoBoldFontOfSize:normalFont.pointSize];
+            [attributedString addAttribute:NSFontAttributeName value:boldFont range:rangeToBoldify];
+        }
     }
     
     return attributedString;


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-824

This logic was relying on a magic "in automation:" string that is no longer present.  We will no longer rely on magic strings in the description.

![tenor](https://user-images.githubusercontent.com/1328743/37857293-29203b88-2eb7-11e8-95ff-b893ab421d61.gif)
