### PR TITLE
IOS-826: Better tolerate stupid server data

### DIFF
--- a/Pod/Classes/Clients/ZNGSocketClient.m
+++ b/Pod/Classes/Clients/ZNGSocketClient.m
@@ -508,7 +508,7 @@
     NSString * lockedByUserID = info[@"lockedByUuid"];
     NSString * meId = accountSession.userAuthorization.userId;
     
-    BOOL lockedByMeMyselfAndI = (([meId length] > 0) && ([lockedByUserID isEqualToString:meId]));
+    BOOL lockedByMeMyselfAndI = (([meId length] > 0) && ([lockedByUserID isEqual:meId]));
     
     if (!lockedByMeMyselfAndI) {
         SBLogInfo(@"Conversation was locked: %@", description);
@@ -525,7 +525,7 @@
     
     NSDictionary * data = [dataArray firstObject];
     NSDictionary * userData = data[@"user"];
-    BOOL isNote = [data[@"type"] isEqualToString:@"note"];
+    BOOL isNote = [data[@"type"] isEqual:@"note"];
     
     if (userData[@"id"] == nil) {
         SBLogWarning(@"Received a userIsReplying notification with no user ID.  Ignoring: %@", data);

--- a/Pod/Classes/UI/ViewModels/Events/ZNGConversationServiceToContact.m
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGConversationServiceToContact.m
@@ -148,7 +148,7 @@ static NSString * const ChannelsKVOPath = @"contact.channels";
 - (BOOL) notificationRelevantToThisConversation:(NSNotification *)notification
 {
     NSString * contactId = [notification.userInfo[ZingleConversationNotificationContactIdKey] copy];
-    return [contactId isEqualToString:self.contact.contactId];
+    return [contactId isEqual:self.contact.contactId];
 }
 
 - (void) notifyContactSelfMutated:(NSNotification *)notification

--- a/Pod/Classes/ZingleAccountSession.m
+++ b/Pod/Classes/ZingleAccountSession.m
@@ -353,7 +353,7 @@ NSString * const ZingleFeedListShouldBeRefreshedNotification = @"ZingleFeedListS
 - (BOOL) notificationRelevantToCurrentService:(NSNotification *)notification
 {
     NSString * serviceId = notification.userInfo[@"aps"][@"service"];
-    return [serviceId isEqualToString:self.service.serviceId];
+    return [serviceId isEqual:self.service.serviceId];
 }
 
 - (void) notifyBecameActive:(NSNotification *)notification

--- a/Pod/Classes/ZingleContactSession.m
+++ b/Pod/Classes/ZingleContactSession.m
@@ -109,7 +109,7 @@
     // We only care about push notifications that specify our current service ID
     NSString * serviceId = notification.userInfo[@"aps"][@"service"];
     
-    if ([serviceId isEqualToString:self.contactService.serviceId]) {
+    if ([serviceId isEqual:self.contactService.serviceId]) {
         [self updateCurrentService];
     }
 }

--- a/Pod/Classes/ZingleSession.m
+++ b/Pod/Classes/ZingleSession.m
@@ -137,7 +137,7 @@ void __userNotificationWillPresent(id self, SEL _cmd, id notificationCenter, id 
         
 + (BOOL) pushNotificationIsRelevantToZingle:(NSDictionary *)userInfo
 {
-    return [userInfo[@"aps"][@"category"] isEqualToString:@"Zingle"];
+    return [userInfo[@"aps"][@"category"] isEqual:@"Zingle"];
 }
 
 #pragma mark - Initializers


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-826

Some notifications very rarely have integers where strings are expected.  Using the string specific equality method caused us to explode.  We will use the slightly less efficient `isEqual` to avoid crashes from unsanitized data.

![bmwbmw-1515089225](https://user-images.githubusercontent.com/1328743/37985329-5478bcd0-31ad-11e8-93d1-130201003476.gif)
