### PR TITLE
Hopefully fixed a data merging crash that has haunted the app forever

### DIFF
--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
@@ -644,9 +644,7 @@ NSString * const ZNGInboxDataSetSortDirectionDescending = @"desc";
             if (overflowCount > 0) {
                 NSRange overflowRangeInIncomingData = NSMakeRange(overlapRangeInTotalData.length, [incomingContacts count] - overlapRangeInTotalData.length);
                 NSArray * overflow = [incomingContacts subarrayWithRange:overflowRangeInIncomingData];
-                NSRange appendRange = NSMakeRange([mutableContacts count], [overflow count]);
-                NSIndexSet * indexSet = [NSIndexSet indexSetWithIndexesInRange:appendRange];
-                [mutableContacts insertObjects:overflow atIndexes:indexSet];    // See note above about insertObjects:AtIndexes: vs. addObjectsFromArray; re: KVO
+                [mutableContacts addObjectsFromArray:overflow];
             }
         }
     }


### PR DESCRIPTION
https://www.fabric.io/zingle/ios/apps/com.zingleme.zingle/issues/59c40f1abe077a4dcc03b1be
https://www.fabric.io/zingle/ios/apps/com.zingleme.zingle/issues/5a316fcc8cb3c2fa63ccf905
https://www.fabric.io/zingle/ios/apps/com.zingleme.zingle/issues/5a8a117c8cb3c2fa6356586b

Removed a rather precise calculation for insertion range that rarely causes a crash.  The trade off is that multiple Key Value Observing notifications will now be sent when multiple contacts arrive at once.  This should have no visible downside.

![app-crash](https://user-images.githubusercontent.com/1328743/38001787-9dd25ae0-31e3-11e8-98dd-716f6eb37d63.gif)
