### PR TITLE
Fixed a typing indicator crash

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
@@ -698,6 +698,7 @@ static void * ZNGConversationKVOContext  =   &ZNGConversationKVOContext;
     //  would scroll down to see just the top of the new bubble but not the entire bubble.
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         CGRect bottomLeft = CGRectMake(0.0, self.collectionView.contentSize.height - 1.0, 1.0, 1.0);
+        SBLogVerbose(@"Scrolling conversation view down to %@", NSStringFromCGRect(bottomLeft));
         [self.collectionView scrollRectToVisible:bottomLeft animated:animated];
     });
 }

--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -315,39 +315,13 @@ enum ZNGConversationSections
             
             [self updateForInputLockedStatus:lockedString oldStatus:oldLockedString];
         } else if ([keyPath isEqualToString:KVOReplyingUsersPath]) {
-            
-            switch ([change[NSKeyValueChangeKindKey] intValue]) {
-                case NSKeyValueChangeInsertion:
-                {
-                    NSIndexSet * indexes = change[NSKeyValueChangeIndexesKey];
-                    [self.collectionView performBatchUpdates:^{
-                        [indexes enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL * _Nonnull stop) {
-                            [self.collectionView insertItemsAtIndexPaths:@[[NSIndexPath indexPathForRow:idx inSection:ZNGConversationSectionTypingIndicators]]];
-                        }];
-                    } completion:^(BOOL finished) {
-                        if (self.stuckToBottom) {
-                            [self scrollToBottomAnimated:YES];
-                        }
-                    }];
-                    break;
-                }
-                    
-                case NSKeyValueChangeRemoval:
-                {
-                    NSIndexSet * indexes = change[NSKeyValueChangeIndexesKey];
-                    [self.collectionView performBatchUpdates:^{
-                        [indexes enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL * _Nonnull stop) {
-                            [self.collectionView deleteItemsAtIndexPaths:@[[NSIndexPath indexPathForItem:idx inSection:ZNGConversationSectionTypingIndicators]]];
-                        }];
-                    } completion:nil];
-                    break;
-                }
-                    
-                default:
-                    [self.collectionView reloadSections:[NSIndexSet indexSetWithIndex:ZNGConversationSectionTypingIndicators]];
-                    
+            // Reload just the typing indicators section.  Warning: Using insert/delete here is hopelessly perilous due to
+            //  our superclasses calling reloadData.
+            [self.collectionView reloadSections:[NSIndexSet indexSetWithIndex:ZNGConversationSectionTypingIndicators]];
+
+            if (([change[NSKeyValueChangeKindKey] intValue] == NSKeyValueChangeInsertion) && (self.stuckToBottom)) {
+                [self scrollToBottomAnimated:YES];
             }
-            
         } else if ([keyPath isEqualToString:KVOTeamAssignment]) {
             [self updateTitle];
         } else if ([keyPath isEqualToString:KVOUserAssignment]) {

--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -318,9 +318,16 @@ enum ZNGConversationSections
             // Reload just the typing indicators section.  Warning: Using insert/delete here is hopelessly perilous due to
             //  our superclasses calling reloadData.
             [self.collectionView reloadSections:[NSIndexSet indexSetWithIndex:ZNGConversationSectionTypingIndicators]];
-
-            if (([change[NSKeyValueChangeKindKey] intValue] == NSKeyValueChangeInsertion) && (self.stuckToBottom)) {
-                [self scrollToBottomAnimated:YES];
+            
+            NSIndexSet * indexes = change[NSKeyValueChangeIndexesKey];
+            
+            // We'll scroll if we're stuck to the bottom and this is an insertion
+            BOOL isInsertion = ([change[NSKeyValueChangeKindKey] intValue] == NSKeyValueChangeInsertion);
+            BOOL hasIndex = ([indexes count] > 0);
+            
+            if ((isInsertion) && (hasIndex) && (self.stuckToBottom)) {
+                SBLogDebug(@"Scrolling to show a new typing indicator.");
+                [self.collectionView scrollToItemAtIndexPath:[NSIndexPath indexPathForItem:[indexes firstIndex] inSection:ZNGConversationSectionTypingIndicators] atScrollPosition:UICollectionViewScrollPositionNone animated:YES];
             }
         } else if ([keyPath isEqualToString:KVOTeamAssignment]) {
             [self updateTitle];


### PR DESCRIPTION
Replaced error-prone insert and delete calls with `reloadSections:` that will not crash if timing is weird vs. the superclasses' refresh logic.

![s--7-hg7pmz--](https://user-images.githubusercontent.com/1328743/38153397-685cef5c-3421-11e8-88b9-c2ea5cfe6bdf.gif)
