### PR TITLE
IOS-828: Name shortening crash

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.h
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.h
@@ -32,6 +32,12 @@
 
 @property (nonatomic, weak, nullable) id <ZNGServiceToContactViewDelegate> delegate;
 
+/**
+ *  Setting this flag hides the contact name (potentially only the first line of the title on services with assignment).
+ *  Used for animated transitions.
+ */
+@property (nonatomic, assign) BOOL hideContactName;
+
 @property (nonatomic, strong, nullable) IBOutlet UIView * automationBannerContainerView;
 @property (nonatomic, strong, nullable) IBOutlet UIView * automationBanner;
 @property (nonatomic, strong, nullable) IBOutlet UILabel * automationLabel;

--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -100,6 +100,8 @@ enum ZNGConversationSections
     BOOL viewHasAppeared;
     BOOL titleWasSingleLineLastUpdate;
     
+    BOOL _hideContactName;
+    
     /**
      *  Used for delayed messages.  Converts NSTimeInterval like 66.0 into "about a minute," etc.
      */
@@ -293,6 +295,12 @@ enum ZNGConversationSections
     [self updateTitle];
 }
 
+- (void) setHideContactName:(BOOL)hideContactName
+{
+    _hideContactName = hideContactName;
+    [self updateTitle];
+}
+
 - (void) observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSString *,id> *)change context:(void *)context
 {
     if (context == KVOContext) {
@@ -400,6 +408,11 @@ enum ZNGConversationSections
     }
     
     NSMutableAttributedString * title = [[NSMutableAttributedString alloc] initWithString:[self.conversation remoteName]];
+    
+    if (self.hideContactName) {
+        [title addAttribute:NSForegroundColorAttributeName value:[UIColor clearColor] range:NSMakeRange(0, [title length])];
+    }
+    
     NSMutableAttributedString * subtitle = [self subtitle];
     BOOL deferUpdateToNextRunLoopCycle = NO;
     

--- a/Pod/Classes/UI/Transitions/ZNGEditContactExitTransition.m
+++ b/Pod/Classes/UI/Transitions/ZNGEditContactExitTransition.m
@@ -62,11 +62,10 @@
     CGRect nameDestinationFrame = CGRectNull;
     UILabel * blueAnimatingNameLabel = nil;
     UILabel * whiteAnimatingNameLabel = nil;
-    __block NSRange nameRange = NSMakeRange(NSNotFound, 0);
     
     if ([conversationTitleLabel isKindOfClass:[UILabel class]]) {
         NSString * contactName = [[conversationTitleLabel.attributedText substringsByLineAndAttributes] firstObject];
-        nameRange = [conversationTitleLabel.text rangeOfString:contactName];
+        NSRange nameRange = [conversationTitleLabel.text rangeOfString:contactName];
         CGRect nameBounds = [conversationTitleLabel boundingRectForTextRange:nameRange];
         
         if (!CGRectIsEmpty(nameBounds)) {
@@ -86,9 +85,7 @@
             [transitionContext.containerView addSubview:whiteAnimatingNameLabel];
             
             // Hide the original name while we animate this name up
-            NSMutableAttributedString * mutableName = [conversationTitleLabel.attributedText mutableCopy];
-            [mutableName addAttribute:NSForegroundColorAttributeName value:[UIColor clearColor] range:nameRange];
-            conversationTitleLabel.attributedText = mutableName;
+            conversationViewController.hideContactName = YES;
         }
     } else {
         SBLogWarning(@"Unable to find title label in conversation view when exiting contact edit view.  The name will not animate.");
@@ -113,13 +110,7 @@
         [animatingBlueness removeFromSuperview];
         
         // Unhide contact name
-        NSMutableAttributedString * mutableName = [conversationTitleLabel.attributedText mutableCopy];
-        NSString * contactName = [[conversationTitleLabel.attributedText substringsByLineAndAttributes] firstObject];
-        
-        // Re-calculate name range.  If a contact's name is being edited, the name will have changed between when we started this transition and now.  Scary.
-        nameRange = [mutableName.string rangeOfString:contactName];
-        [mutableName removeAttribute:NSForegroundColorAttributeName range:nameRange];
-        conversationTitleLabel.attributedText = mutableName;
+        conversationViewController.hideContactName = NO;
         
         [transitionContext completeTransition:YES];
     }];

--- a/Pod/Classes/UI/Transitions/ZNGEditContactExitTransition.m
+++ b/Pod/Classes/UI/Transitions/ZNGEditContactExitTransition.m
@@ -62,7 +62,7 @@
     CGRect nameDestinationFrame = CGRectNull;
     UILabel * blueAnimatingNameLabel = nil;
     UILabel * whiteAnimatingNameLabel = nil;
-    NSRange nameRange = NSMakeRange(NSNotFound, 0);
+    __block NSRange nameRange = NSMakeRange(NSNotFound, 0);
     
     if ([conversationTitleLabel isKindOfClass:[UILabel class]]) {
         NSString * contactName = [[conversationTitleLabel.attributedText substringsByLineAndAttributes] firstObject];
@@ -114,6 +114,10 @@
         
         // Unhide contact name
         NSMutableAttributedString * mutableName = [conversationTitleLabel.attributedText mutableCopy];
+        NSString * contactName = [[conversationTitleLabel.attributedText substringsByLineAndAttributes] firstObject];
+        
+        // Re-calculate name range.  If a contact's name is being edited, the name will have changed between when we started this transition and now.  Scary.
+        nameRange = [mutableName.string rangeOfString:contactName];
         [mutableName removeAttribute:NSForegroundColorAttributeName range:nameRange];
         conversationTitleLabel.attributedText = mutableName;
         

--- a/Pod/Classes/UI/Transitions/ZNGEditContactTransition.m
+++ b/Pod/Classes/UI/Transitions/ZNGEditContactTransition.m
@@ -71,8 +71,6 @@
     
     UILabel * animatingNameLabel = nil;
     CGRect animatingNameFinalFrame = CGRectZero;
-    NSRange hiddenTitleRange = NSMakeRange(NSNotFound, 0);
-    __block UIColor * hiddenTitleColor = nil;
     
     // Find the location of the contact's name in our old header
     UILabel * fromTitleLabel = (UILabel *)conversationViewController.navigationItem.titleView;
@@ -92,14 +90,7 @@
         
         if (animatingName != nil) {
             // Hide the name
-            hiddenTitleRange = [fromTitleLabel.text rangeOfString:animatingName];
-            NSMutableAttributedString * attributedTitleText = [fromTitleLabel.attributedText mutableCopy];
-            [attributedTitleText enumerateAttribute:NSForegroundColorAttributeName inRange:hiddenTitleRange options:0 usingBlock:^(id  _Nullable value, NSRange range, BOOL * _Nonnull stop) {
-                hiddenTitleColor = value;
-                *stop = YES;
-            }];
-            [attributedTitleText addAttribute:NSForegroundColorAttributeName value:[UIColor clearColor] range:hiddenTitleRange];
-            fromTitleLabel.attributedText = attributedTitleText;
+            conversationViewController.hideContactName = YES;
             
             CGRect animatingNameStartBounds = [self frameForSubstring:animatingName withinLabel:fromTitleLabel];
             CGRect animatingNameStartFrame = [fromTitleLabel convertRect:animatingNameStartBounds toView:fromViewController.view];
@@ -125,10 +116,8 @@
                 animatingNameLabel.transform = CGAffineTransformMakeScale(startingScale, startingScale);
                 animatingNameLabel.alpha = 0.58;
                 
-                // Hide the name that we are animating and the destination label
+                // Hide the destination label
                 toViewController.assignmentLabel.hidden = YES;
-                [attributedTitleText addAttribute:NSForegroundColorAttributeName value:[UIColor clearColor] range:hiddenTitleRange];
-                fromTitleLabel.attributedText = attributedTitleText;
             }
         }
     } else {
@@ -186,16 +175,7 @@
         // Restore any text that we hid above
         toViewController.assignmentLabel.hidden = NO;
         fromTitleLabel.alpha = 1.0;
-        NSMutableAttributedString * text = [fromTitleLabel.attributedText mutableCopy];
-        [text enumerateAttribute:NSForegroundColorAttributeName inRange:NSMakeRange(0, [text length]) options:0 usingBlock:^(UIColor * _Nullable value, NSRange range, BOOL * _Nonnull stop) {
-            if ([value isEqual:[UIColor clearColor]]) {
-                [text removeAttribute:NSForegroundColorAttributeName range:range];
-            }
-        }];
-        if (hiddenTitleColor != nil) {
-            [text addAttribute:NSForegroundColorAttributeName value:hiddenTitleColor range:hiddenTitleRange];
-        }
-        fromTitleLabel.attributedText = text;
+        conversationViewController.hideContactName = NO;
         
         // Restore the header color and button visibility
         toViewController.titleContainer.backgroundColor = headerColor;

--- a/Pod/Classes/UI/Transitions/ZNGEditContactTransition.m
+++ b/Pod/Classes/UI/Transitions/ZNGEditContactTransition.m
@@ -172,25 +172,24 @@
         // Bring the view up into the frame
         toSnapshot.frame = toViewFinalFrame;
     } completion:^(BOOL finished) {
-        // Restore any text that we hid above
+        // Restore hidden things
         toViewController.assignmentLabel.hidden = NO;
         fromTitleLabel.alpha = 1.0;
         conversationViewController.hideContactName = NO;
-        
-        // Restore the header color and button visibility
+        conversationViewController.navigationItem.titleView.hidden = NO;
         toViewController.titleContainer.backgroundColor = headerColor;
         toViewController.cancelButton.hidden = NO;
         toViewController.saveButton.hidden = NO;
-        
-        conversationViewController.navigationItem.titleView.hidden = NO;
-        
         toViewController.view.hidden = NO;
+        
+        // Remove our animating views
         [toSnapshot removeFromSuperview];
         [animatingHeader removeFromSuperview];
         [animatingTitle removeFromSuperview];
         [oldColorAnimatingTitle removeFromSuperview];
         [animatingNameLabel removeFromSuperview];
         
+        // We done
         [transitionContext completeTransition:YES];
     }];
 }


### PR DESCRIPTION
Shortening a contact's name caused a crash.  Yeah.

![skyfall](https://user-images.githubusercontent.com/1328743/38280749-e8d443d2-375b-11e8-9855-bc3a03fa4c71.gif)
