### PR TITLE
Fixed an int vs string type issue in badge code

### DIFF
--- a/Example/Tests/TestInboxStatistician.m
+++ b/Example/Tests/TestInboxStatistician.m
@@ -52,10 +52,10 @@
     return @[@{
                  @"unassigned": zeroStatsDictionary,
                  @"teams": @{
-                         @(team.numericId): zeroStatsDictionary,
+                         [@(team.numericId) stringValue]: zeroStatsDictionary,
                          },
                  @"users": @{
-                         @(user.numericId): zeroStatsDictionary,
+                         [@(user.numericId) stringValue]: zeroStatsDictionary,
                          },
                  }];
 }
@@ -89,10 +89,10 @@
     
     return @[@{
                  @"teams": @{
-                         @12345: nonZeroTeamDictionary,
+                         @"12345": nonZeroTeamDictionary,
                          },
                  @"users": @{
-                         @5678: nonZeroUserDictionary,
+                         @"5678": nonZeroUserDictionary,
                          },
                  }];
 }
@@ -119,10 +119,10 @@
     return @[@{
              @"unassigned": zeroUnassignedDictionary,
              @"teams": @{
-                     @(team.numericId): nonZeroTeamDictionary,
+                     [@(team.numericId) stringValue]: nonZeroTeamDictionary,
                      },
              @"users": @{
-                     @(user.numericId): nonZeroUserDictionary,
+                     [@(user.numericId) stringValue]: nonZeroUserDictionary,
                      },
              }];
 }

--- a/Pod/Classes/UI/ViewModels/Inbox Badges/ZNGInboxStatistician.m
+++ b/Pod/Classes/UI/ViewModels/Inbox Badges/ZNGInboxStatistician.m
@@ -70,7 +70,7 @@ NSString * const ZNGInboxStatisticianDataChangedNotification = @"ZNGInboxStatist
         
         // Remove any unincluded teams
         for (NSNumber * teamId in [[teamStats allKeys] copy]) {
-            if (teams[teamId] == nil) {
+            if (teams[[teamId stringValue]] == nil) {
                 [teamStats removeObjectForKey:teamId];
             }
         }
@@ -86,7 +86,7 @@ NSString * const ZNGInboxStatisticianDataChangedNotification = @"ZNGInboxStatist
         
         // Remove any unincluded users
         for (NSNumber * userId in [[userStats allKeys] copy]) {
-            if (users[userId] == nil) {
+            if (users[[userId stringValue]] == nil) {
                 [userStats removeObjectForKey:userId];
             }
         }


### PR DESCRIPTION
Our unit tests were using integers, but the server sends strings.  Corrected that.

![2fc52716960cfc32f9ef69c75673a42b](https://user-images.githubusercontent.com/1328743/38825403-4add0f96-4161-11e8-9cfe-3fa7a3dd16e5.gif)
