### PR TITLE
Added user settings for inboxes/users display

### DIFF
--- a/Pod/Classes/Clients/ZNGSocketClient.m
+++ b/Pod/Classes/Clients/ZNGSocketClient.m
@@ -225,7 +225,7 @@
     }];
     
     [socketClient on:@"serviceUsersData" callback:^(NSArray * _Nonnull data, SocketAckEmitter * _Nonnull ackEmitter) {
-        [weakSelf receivedUserData:data ackEmitter:ackEmitter];
+        [weakSelf receivedUsersData:data ackEmitter:ackEmitter];
     }];
     
     [socketClient on:@"badgeData" callback:^(NSArray * _Nonnull data, SocketAckEmitter * _Nonnull ackEmitter) {
@@ -403,7 +403,7 @@
     [session updateUserData];
 }
 
-- (void) receivedUserData:(NSArray *)data ackEmitter:(SocketAckEmitter *)ackEmitter
+- (void) receivedUsersData:(NSArray *)data ackEmitter:(SocketAckEmitter *)ackEmitter
 {
     if (![self.session isKindOfClass:[ZingleAccountSession class]]) {
         return;

--- a/Pod/Classes/Clients/ZNGSocketClient.m
+++ b/Pod/Classes/Clients/ZNGSocketClient.m
@@ -220,6 +220,10 @@
         [weakSelf receivedServiceData:data ackEmitter:ackEmitter];
     }];
     
+    [socketClient on:@"userUpdated" callback:^(NSArray * _Nonnull data, SocketAckEmitter * _Nonnull ackEmitter) {
+        [weakSelf receivedCurrentUserData:data ackEmitter:ackEmitter];
+    }];
+    
     [socketClient on:@"serviceUsersData" callback:^(NSArray * _Nonnull data, SocketAckEmitter * _Nonnull ackEmitter) {
         [weakSelf receivedUserData:data ackEmitter:ackEmitter];
     }];
@@ -387,6 +391,16 @@
 - (void) receivedRefreshFeeds:(NSArray *)data ackEmitter:(SocketAckEmitter *)ackEmitter
 {
     [[NSNotificationCenter defaultCenter] postNotificationName:ZingleFeedListShouldBeRefreshedNotification object:nil];
+}
+
+- (void) receivedCurrentUserData:(NSArray *)data ackEmitter:(SocketAckEmitter *)ackEmitter
+{
+    if (![self.session isKindOfClass:[ZingleAccountSession class]]) {
+        return;
+    }
+    
+    ZingleAccountSession * session = (ZingleAccountSession *)self.session;
+    [session updateUserData];
 }
 
 - (void) receivedUserData:(NSArray *)data ackEmitter:(SocketAckEmitter *)ackEmitter

--- a/Pod/Classes/Models/ZNGUser.h
+++ b/Pod/Classes/Models/ZNGUser.h
@@ -12,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class ZNGService;
 @class ZNGUserAuthorization;
+@class ZNGUserSettings;
 
 @interface ZNGUser : MTLModel<MTLJSONSerializing>
 
@@ -25,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong, nullable) NSArray* serviceIds;
 @property(nonatomic, strong, nullable) NSURL * avatarUri;
 @property(nonatomic, strong, nullable) NSDictionary<NSString *, NSArray<NSString *> *> * servicePrivileges;
+@property(nonatomic, strong, nullable) ZNGUserSettings * settings;
 @property (nonatomic, assign) BOOL isOnline;
 
 - (NSString * _Nullable) fullName;

--- a/Pod/Classes/Models/ZNGUser.m
+++ b/Pod/Classes/Models/ZNGUser.m
@@ -10,6 +10,7 @@
 #import "ZNGService.h"
 #import "ZNGUserAuthorization.h"
 #import "UIImage+CircleCrop.h"
+#import "ZNGUserSettings.h"
 
 @import SDWebImage;
 
@@ -29,7 +30,23 @@ static NSString * const ZNGUserPrivilegeMonitorTeams = @"monitor_teams";
              @"serviceIds" : @"service_ids",
              @"avatarUri" : @"avatar_uri",
              NSStringFromSelector(@selector(servicePrivileges)): @"service_privileges",
+             NSStringFromSelector(@selector(settings)): @"settings",
              };
+}
+
++ (NSValueTransformer *)settingsJSONTransformer
+{
+    return [MTLJSONAdapter dictionaryTransformerWithModelClass:[ZNGUserSettings class]];
+}
+
+#warning Remove temporary testing getter
+- (ZNGUserSettings *) settings
+{
+    if (_settings == nil) {
+        _settings = [[ZNGUserSettings alloc] init];
+    }
+    
+    return _settings;
 }
 
 - (BOOL) isEqual:(ZNGUser *)other

--- a/Pod/Classes/Models/ZNGUser.m
+++ b/Pod/Classes/Models/ZNGUser.m
@@ -18,6 +18,20 @@ static NSString * const ZNGUserPrivilegeMonitorTeams = @"monitor_teams";
 
 @implementation ZNGUser
 
+- (id) initWithDictionary:(NSDictionary *)dictionaryValue error:(NSError *__autoreleasing *)error
+{
+    self = [super initWithDictionary:dictionaryValue error:error];
+    
+    if (self != nil) {
+        // If settings is nil, set an empty settings object to allow local defaults
+        if (_settings == nil) {
+            _settings = [[ZNGUserSettings alloc] init];
+        }
+    }
+    
+    return self;
+}
+
 + (NSDictionary*)JSONKeyPathsByPropertyKey
 {
     return @{
@@ -32,21 +46,6 @@ static NSString * const ZNGUserPrivilegeMonitorTeams = @"monitor_teams";
              NSStringFromSelector(@selector(servicePrivileges)): @"service_privileges",
              NSStringFromSelector(@selector(settings)): @"settings",
              };
-}
-
-+ (NSValueTransformer *)settingsJSONTransformer
-{
-    return [MTLJSONAdapter dictionaryTransformerWithModelClass:[ZNGUserSettings class]];
-}
-
-#warning Remove temporary testing getter
-- (ZNGUserSettings *) settings
-{
-    if (_settings == nil) {
-        _settings = [[ZNGUserSettings alloc] init];
-    }
-    
-    return _settings;
 }
 
 - (BOOL) isEqual:(ZNGUser *)other

--- a/Pod/Classes/Models/ZNGUserSettings.h
+++ b/Pod/Classes/Models/ZNGUserSettings.h
@@ -1,0 +1,16 @@
+//
+//  ZNGUserSettings.h
+//  ZingleSDK
+//
+//  Created by Jason Neel on 4/20/18.
+//
+
+#import <Mantle/Mantle.h>
+
+@interface ZNGUserSettings : MTLModel <MTLJSONSerializing>
+
+// Properties are NSNumber instead of BOOL to allow nullability and YES-defaulting in getter methods
+@property (nonatomic, strong, nullable) NSNumber * showOnlyMyTeammates;
+@property (nonatomic, strong, nullable) NSNumber * showUnassignedConversations;
+
+@end

--- a/Pod/Classes/Models/ZNGUserSettings.m
+++ b/Pod/Classes/Models/ZNGUserSettings.m
@@ -17,7 +17,7 @@
              };
 }
 
-// Default to YES for showOnlyMyTeammates
+// Default to YES for showUnassignedConversations
 - (NSNumber *) showUnassignedConversations
 {
     if (_showUnassignedConversations == nil) {
@@ -25,6 +25,16 @@
     }
 
     return _showUnassignedConversations;
+}
+
+// Default to YES for showOnlyMyTeammates
+- (NSNumber *) showOnlyMyTeammates
+{
+    if (_showOnlyMyTeammates == nil) {
+        return @YES;
+    }
+    
+    return _showOnlyMyTeammates;
 }
 
 @end

--- a/Pod/Classes/Models/ZNGUserSettings.m
+++ b/Pod/Classes/Models/ZNGUserSettings.m
@@ -1,0 +1,30 @@
+//
+//  ZNGUserSettings.m
+//  ZingleSDK
+//
+//  Created by Jason Neel on 4/20/18.
+//
+
+#import "ZNGUserSettings.h"
+
+@implementation ZNGUserSettings
+
++ (NSDictionary*)JSONKeyPathsByPropertyKey
+{
+    return @{
+             NSStringFromSelector(@selector(showOnlyMyTeammates)): @"show_only_my_teammates",
+             NSStringFromSelector(@selector(showUnassignedConversations)): @"show_unassigned_conversations",
+             };
+}
+
+// Default to YES for showOnlyMyTeammates
+- (NSNumber *) showUnassignedConversations
+{
+    if (_showUnassignedConversations == nil) {
+        return @YES;
+    }
+
+    return _showUnassignedConversations;
+}
+
+@end

--- a/Pod/Classes/ZingleAccountSession.h
+++ b/Pod/Classes/ZingleAccountSession.h
@@ -192,6 +192,13 @@ extern NSString * const ZingleFeedListShouldBeRefreshedNotification;
 - (NSArray<ZNGUser *> * _Nonnull) usersIncludingSelf:(BOOL)includeSelf;
 
 /**
+ *  Returns only users that share at least one team with the current user.
+ *  Includes the current user if `includeSelf` is YES.
+ *  Returns @[] if team assignment is not enabled on the service.
+ */
+- (NSArray<ZNGUser *> * _Nonnull) usersOnCommonTeamsIncludingSelf:(BOOL)includeSelf;
+
+/**
  *  The user with the provided UUID, if available
  */
 - (ZNGUser * _Nullable) userWithId:(NSString *)userId;

--- a/Pod/Classes/ZingleAccountSession.m
+++ b/Pod/Classes/ZingleAccountSession.m
@@ -29,6 +29,7 @@
 #import "ZNGInboxStatsEntry.h"
 #import "ZNGAssignmentViewController.h"
 #import "ZNGNotificationSettingsClient.h"
+#import "ZNGTeam.h"
 
 @import AFNetworking;
 @import SBObjectiveCWrapper;
@@ -630,6 +631,35 @@ NSString * const ZingleFeedListShouldBeRefreshedNotification = @"ZingleFeedListS
     for (ZNGUser * dude in self.users) {
         if (![dude.userId isEqualToString:self.userAuthorization.userId]) {
             [filteredUsers addObject:dude];
+        }
+    }
+    
+    return filteredUsers;
+}
+
+- (NSArray<ZNGUser *> * _Nonnull) usersOnCommonTeamsIncludingSelf:(BOOL)includeSelf
+{
+    if (![self.service allowsTeamAssignment]) {
+        return @[];
+    }
+    
+    NSArray<ZNGTeam *> * currentUserTeams = [self teamsToWhichCurrentUserBelongs];
+    NSMutableArray<ZNGUser *> * filteredUsers = [[NSMutableArray alloc] init];
+    
+    for (ZNGUser * dude in self.users) {
+        if ([dude.userId isEqualToString:self.userAuthorization.userId]) {
+            // This is the current user
+            if (includeSelf) {
+                [filteredUsers addObject:dude];
+            }
+        } else {
+            // This is someone else.  Do they have any of our teams in common?
+            for (ZNGTeam * team in currentUserTeams) {
+                if ([team.userIds containsObject:dude.userId]) {
+                    [filteredUsers addObject:dude];
+                    break;
+                }
+            }
         }
     }
     

--- a/Pod/Classes/ZingleAccountSession.m
+++ b/Pod/Classes/ZingleAccountSession.m
@@ -514,7 +514,7 @@ NSString * const ZingleFeedListShouldBeRefreshedNotification = @"ZingleFeedListS
 }
 
 /**
- *  Retrieve ZNGUserAuthorization and ZNGUser objects.  Method returns once both requests complete.
+ *  Retrieve ZNGUserAuthorization object.  Method returns once the request completes.
  */
 - (void) synchronouslyRetrieveUserData
 {


### PR DESCRIPTION
- Added `settings` to `ZNGUser`
- Made both view settings, `showOnlyMyTeammates` and `showUnassignedConversations`, default to `true` if unspecified
- Added a method to retrieve only users that share at least one team with the current user (to facilitate `showOnlyMyTeammates`

![giphy](https://user-images.githubusercontent.com/1328743/39264168-123732a6-4879-11e8-84dd-756be60f8b72.gif)
