### PR TITLE
Stop counting unassigned for badge number if unassigned inbox is disabled

### DIFF
--- a/Pod/Classes/ZingleAccountSession.m
+++ b/Pod/Classes/ZingleAccountSession.m
@@ -161,7 +161,8 @@ NSString * const ZingleFeedListShouldBeRefreshedNotification = @"ZingleFeedListS
 
 - (void) notifyBadgeDataChanged:(NSNotification *)notification
 {
-    BOOL countUnassigned = [self.userAuthorization.settings.showUnassignedConversations boolValue];
+    BOOL assignmentDisabled = !([self.service allowsAssignment]);
+    BOOL countUnassigned = ((assignmentDisabled) || ([self.userAuthorization.settings.showUnassignedConversations boolValue]));
     ZNGInboxStatsEntry * totalStats = [self.inboxStatistician combinedStatsForUser:self.userAuthorization teams:[self teamsToWhichCurrentUserBelongs] includeUnassigned:countUnassigned];
     
     if (self.totalUnreadCount != totalStats.unreadCount) {

--- a/Pod/Classes/ZingleAccountSession.m
+++ b/Pod/Classes/ZingleAccountSession.m
@@ -30,6 +30,7 @@
 #import "ZNGAssignmentViewController.h"
 #import "ZNGNotificationSettingsClient.h"
 #import "ZNGTeam.h"
+#import "ZNGUserSettings.h"
 
 @import AFNetworking;
 @import SBObjectiveCWrapper;
@@ -160,7 +161,8 @@ NSString * const ZingleFeedListShouldBeRefreshedNotification = @"ZingleFeedListS
 
 - (void) notifyBadgeDataChanged:(NSNotification *)notification
 {
-    ZNGInboxStatsEntry * totalStats = [self.inboxStatistician combinedStatsForUser:self.userAuthorization teams:[self teamsToWhichCurrentUserBelongs] includeUnassigned:YES];
+    BOOL countUnassigned = [self.userAuthorization.settings.showUnassignedConversations boolValue];
+    ZNGInboxStatsEntry * totalStats = [self.inboxStatistician combinedStatsForUser:self.userAuthorization teams:[self teamsToWhichCurrentUserBelongs] includeUnassigned:countUnassigned];
     
     if (self.totalUnreadCount != totalStats.unreadCount) {
         SBLogDebug(@"Badge count changed from %llu to %llu", (unsigned long long)self.totalUnreadCount, (unsigned long long)totalStats.unreadCount);
@@ -504,6 +506,19 @@ NSString * const ZingleFeedListShouldBeRefreshedNotification = @"ZingleFeedListS
     
     _users = [users sortedArrayUsingDescriptors:@[activeStatus, firstName]];
     dispatch_semaphore_signal(initialUserDataSemaphore);
+}
+
+- (void) setUserAuthorization:(ZNGUserAuthorization *)userAuthorization
+{
+    ZNGUserSettings * oldSettings = self.userAuthorization.settings;
+    
+    _userAuthorization = userAuthorization;
+    
+    // If "show unassigned" has changed, we need to refresh the badge count
+    if ([oldSettings.showUnassignedConversations boolValue] != [userAuthorization.settings.showUnassignedConversations boolValue]) {
+        SBLogInfo(@"Re-calculating badge count due to a change in the user's view unassigned setting.");
+        [self notifyBadgeDataChanged:nil];
+    }
 }
 
 - (void) updateUserData


### PR DESCRIPTION
... in the user's settings (and if assignment is enabled)

![anigif_enhanced-buzz-12347-1366729320-1](https://user-images.githubusercontent.com/1328743/39337235-b8fb942c-4970-11e8-8d33-8d5f40425004.gif)
