### PR TITLE
Fix edit contact name animation bug on iPad

### DIFF
--- a/Pod/Classes/UI/Transitions/ZNGEditContactTransition.m
+++ b/Pod/Classes/UI/Transitions/ZNGEditContactTransition.m
@@ -98,8 +98,9 @@
             
             // As of iOS SDK 11.3, the above convertRect:toView: adjusts the Y coordinate correctly but does not adjust X.
             // We will manually Xify the frame.  This adjustment will have no effect if this bug is fixed later.
+            CGPoint conversationCenterInWindow = [conversationViewController.view convertPoint:conversationViewController.view.center toView:nil];
             CGFloat nameDistanceFromCenterX = animatingNameStartBounds.origin.x - (fromTitleLabel.bounds.size.width / 2.0);
-            CGFloat animatingNameStartX = (fromViewController.view.bounds.size.width / 2.0) + nameDistanceFromCenterX;
+            CGFloat animatingNameStartX = conversationCenterInWindow.x + nameDistanceFromCenterX;
             animatingNameStartFrame = CGRectMake(animatingNameStartX,
                                                  animatingNameStartFrame.origin.y,
                                                  animatingNameStartFrame.size.width,


### PR DESCRIPTION
The conversation view is not necessarily full width.  Oops.  Let's take that into account.

![partial-agonist](https://user-images.githubusercontent.com/1328743/39388454-eb6f6496-4a34-11e8-9faa-ef18389484f3.gif)
