### PR TITLE
Recognize multiple push notification categories

### DIFF
--- a/Pod/Classes/ZingleSession.m
+++ b/Pod/Classes/ZingleSession.m
@@ -137,7 +137,15 @@ void __userNotificationWillPresent(id self, SEL _cmd, id notificationCenter, id 
         
 + (BOOL) pushNotificationIsRelevantToZingle:(NSDictionary *)userInfo
 {
-    return [userInfo[@"aps"][@"category"] isEqual:@"Zingle"];
+    NSString * category = userInfo[@"aps"][@"category"];
+    
+    if (![category isKindOfClass:[NSString class]]) {
+        return NO;
+    }
+    
+    // Does the category start with "Zingle"?
+    NSRange zinglePrefixRange = [category rangeOfString:@"zingle" options:NSCaseInsensitiveSearch];
+    return (zinglePrefixRange.location == 0);
 }
 
 #pragma mark - Initializers


### PR DESCRIPTION
Push notifications were discarded as Zingle-irrelevant if their category was not exactly "Zingle".  We now check for anything _beginning_ with "zingle".

![tenor](https://user-images.githubusercontent.com/1328743/39596426-2bf430dc-4ec7-11e8-9dd7-921cb26997bc.gif)
