### PR TITLE
Added close/confirm methods with completion blocks

### DIFF
--- a/Pod/Classes/Models/ZNGContact/ZNGContact.h
+++ b/Pod/Classes/Models/ZNGContact/ZNGContact.h
@@ -153,6 +153,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (void) assignToUserWithId:(NSString *)userId;
 - (void) unassign;
 
+- (void) closeWithCompletion:(void (^_Nullable)(BOOL succeeded))completion;
+- (void) reopenWithCompletion:(void (^_Nullable)(BOOL succeeded))completion;
+- (void) confirmWithCompletion:(void (^_Nullable)(BOOL succeeded))completion;
+- (void) unconfirmWithCompletion:(void (^_Nullable)(BOOL succeeded))completion;
+
+
 NS_ASSUME_NONNULL_END
 
 @end


### PR DESCRIPTION
Adding background close/mark read/reply actions means we need a positive response to allow error reporting on failures.

![toptal-blog-image-1391722436512](https://user-images.githubusercontent.com/1328743/39645668-f4c6f172-4f8d-11e8-9b67-c2e46510ebb1.gif)
