### PR TITLE
IOS-838: Adjusted user settings defaults to match web

### DIFF
--- a/Pod/Classes/Models/ZNGUserSettings.h
+++ b/Pod/Classes/Models/ZNGUserSettings.h
@@ -9,8 +9,18 @@
 
 @interface ZNGUserSettings : MTLModel <MTLJSONSerializing>
 
-// Properties are NSNumber instead of BOOL to allow nullability and YES-defaulting in getter methods
+// Properties are NSNumber instead of BOOL to allow nullability and defaulting in getter methods
+
+/**
+ *  When this is `@YES`, inbox UI should only display users that share one or more teams with the current user.
+ *  Defaults to `@YES`.
+ */
 @property (nonatomic, strong, nullable) NSNumber * showOnlyMyTeammates;
+
+/**
+ *  When this is `@YES`, an unassigned inbox should be available to the user in servies with assignment enabled.
+ *  Defaults to nil.
+ */
 @property (nonatomic, strong, nullable) NSNumber * showUnassignedConversations;
 
 @end

--- a/Pod/Classes/Models/ZNGUserSettings.m
+++ b/Pod/Classes/Models/ZNGUserSettings.m
@@ -27,14 +27,4 @@
     return _showUnassignedConversations;
 }
 
-// Default to YES for showOnlyMyTeammates
-- (NSNumber *) showOnlyMyTeammates
-{
-    if (_showOnlyMyTeammates == nil) {
-        return @YES;
-    }
-    
-    return _showOnlyMyTeammates;
-}
-
 @end


### PR DESCRIPTION
iOS was defaulting to showing only users who share a team with the current user if the user had never selected either option in My Settings.  Web did the opposite.  Now iOS will be more webby.

![peacock-spider](https://user-images.githubusercontent.com/1328743/39887396-f922b478-5446-11e8-8ac8-53074ae2f493.gif)
