### PR TITLE
IOS-849: Fix method name collision that broke conversation tickles

### DIFF
--- a/Pod/Classes/UI/ViewModels/Events/ZNGConversation.m
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGConversation.m
@@ -117,7 +117,7 @@ static const CGFloat imageAttachmentMaxHeight = 800.0;
         _replyingUsers = [[NSOrderedSet alloc] init];
         typingIndicatorUserExpirationTimers = [NSMapTable mapTableWithKeyOptions:NSMapTableStrongMemory valueOptions:NSMapTableWeakMemory];
         
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(notifyConversationDataReceived:) name:ZingleConversationDataArrivedNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(zng_notifyConversationDataReceived:) name:ZingleConversationDataArrivedNotification object:nil];
     }
     
     return self;
@@ -573,7 +573,7 @@ static const CGFloat imageAttachmentMaxHeight = 800.0;
     return YES;
 }
 
-- (void) notifyConversationDataReceived:(NSNotification *)notification
+- (void) zng_notifyConversationDataReceived:(NSNotification *)notification
 {
     if ((self.automaticallyRefreshes) && ([self notificationRelevantToThisConversation:notification])) {
         [self loadRecentEventsErasingOlderData:NO];


### PR DESCRIPTION
A private method, `notifyConversationDataReceived:`, was added in a subclass of `ZNGConversation` that accidentally overrode the method that refreshed conversation data when a tickle was received.  Sometimes being consistent is a bad thing.

![badrats_badratsshow](https://user-images.githubusercontent.com/1328743/40148644-edcd64c4-5923-11e8-8fe8-ff742dd5ec7a.gif)
