### PR TITLE
IOS-843: Reduce aggressiveness of automatically marking conversations read

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -273,6 +273,12 @@ enum ZNGConversationSections
     UIMenuItem * forward = [[UIMenuItem alloc] initWithTitle:@"Forward" action:@selector(forwardMessage:)];
     [[UIMenuController sharedMenuController] setMenuItems:@[forward]];
     [JSQMessagesCollectionViewCell registerMenuAction:@selector(forwardMessage:)];
+    
+    // Mark read
+    if ((self.conversation.contact != nil) && (!self.conversation.contact.isConfirmed)) {
+        SBLogInfo(@"Confirming contact due to conversation view appearance.");
+        [self.conversation.contact confirm];
+    }
 }
 
 - (void) viewDidAppear:(BOOL)animated
@@ -280,12 +286,6 @@ enum ZNGConversationSections
     [super viewDidAppear:animated];
     
     viewHasAppeared = YES;
-    
-    if ((self.stuckToBottom) && (self.conversation.contact != nil) && (!self.conversation.contact.isConfirmed)) {
-        SBLogInfo(@"Confirming contact due to conversation view appearance.");
-        [self.conversation.contact confirm];
-    }
-    
     [self updateTopInset];
 }
 


### PR DESCRIPTION
Conversations were being marked read any time they appeared on screen, including when reappearing out from under a modal view.  They will be marked read when they are initially loaded, when scrolling back to the most recent messages after viewing older ones, and when "mark read" is selected.

![1521481692939](https://user-images.githubusercontent.com/1328743/40150173-fc94f536-592c-11e8-8970-d266a45a022e.gif)
