### PR TITLE
IOS-835: Use tag/segment pills instead of ugly text

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGLabelSelectViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGLabelSelectViewController.m
@@ -44,6 +44,7 @@ static NSString * const LabelCellId = @"labelCell";
     searchController.dimsBackgroundDuringPresentation = NO;
     self.definesPresentationContext = YES;
     
+    searchController.searchBar.tintColor = [UIColor whiteColor];
     searchController.searchBar.barTintColor = [UIColor zng_lightBlue];
     
     self.tableView.tableHeaderView = searchController.searchBar;

--- a/Pod/Classes/UI/Views/Contact Editing/ZNGLabelTableViewCell.h
+++ b/Pod/Classes/UI/Views/Contact Editing/ZNGLabelTableViewCell.h
@@ -1,0 +1,16 @@
+//
+//  ZNGLabelTableViewCell.h
+//  ZingleSDK
+//
+//  Created by Jason Neel on 5/22/18.
+//
+
+#import <UIKit/UIKit.h>
+
+@class ZNGDashedBorderLabel;
+
+@interface ZNGLabelTableViewCell : UITableViewCell
+
+@property (nonatomic, weak, nullable) IBOutlet ZNGDashedBorderLabel * labelLabel;
+
+@end

--- a/Pod/Classes/UI/Views/Contact Editing/ZNGLabelTableViewCell.m
+++ b/Pod/Classes/UI/Views/Contact Editing/ZNGLabelTableViewCell.m
@@ -1,0 +1,12 @@
+//
+//  ZNGLabelTableViewCell.m
+//  ZingleSDK
+//
+//  Created by Jason Neel on 5/22/18.
+//
+
+#import "ZNGLabelTableViewCell.h"
+
+@implementation ZNGLabelTableViewCell
+
+@end

--- a/Pod/Classes/UI/Views/Contact Editing/ZNGLabelTableViewCell.xib
+++ b/Pod/Classes/UI/Views/Contact Editing/ZNGLabelTableViewCell.xib
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <customFonts key="customFonts">
+        <array key="Lato-Regular.ttf">
+            <string>Lato-Regular</string>
+        </array>
+    </customFonts>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="42" id="KGk-i7-Jjw" customClass="ZNGLabelTableViewCell">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="40"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="39.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rDn-fl-8kW" customClass="ZNGDashedBorderLabel">
+                        <rect key="frame" x="16" y="11" width="30.5" height="16"/>
+                        <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="13"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="number" keyPath="textInset">
+                                <real key="value" value="6"/>
+                            </userDefinedRuntimeAttribute>
+                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                <real key="value" value="14"/>
+                            </userDefinedRuntimeAttribute>
+                            <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                <real key="value" value="2"/>
+                            </userDefinedRuntimeAttribute>
+                        </userDefinedRuntimeAttributes>
+                    </label>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="rDn-fl-8kW" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="Pcj-6I-4rY"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="rDn-fl-8kW" secondAttribute="bottom" priority="700" id="T3G-aF-PKO"/>
+                    <constraint firstAttribute="trailingMargin" relation="greaterThanOrEqual" secondItem="rDn-fl-8kW" secondAttribute="trailing" id="dhL-3E-Qxm"/>
+                    <constraint firstItem="rDn-fl-8kW" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="fMp-mg-smT"/>
+                    <constraint firstItem="rDn-fl-8kW" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" priority="750" id="fRd-07-VcY"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="aW0-zy-SZf"/>
+            <connections>
+                <outlet property="labelLabel" destination="rDn-fl-8kW" id="fFB-2t-6Wi"/>
+            </connections>
+        </tableViewCell>
+    </objects>
+</document>


### PR DESCRIPTION
The "add tag" UI when editing a contact was still using the old, ugly UI.

![maxresdefault](https://user-images.githubusercontent.com/1328743/40505164-4228c3cc-5f48-11e8-8ae8-0e0ead4d0d8e.jpg)
