### PR TITLE
IOS-848: Fixed local vs. international phone number display in inbox

### DIFF
--- a/Pod/Classes/Models/ZNGContact/ZNGContact.h
+++ b/Pod/Classes/Models/ZNGContact/ZNGContact.h
@@ -84,6 +84,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable ZNGChannel *)channelOfType:(ZNGChannelType *)type;
 
 - (nullable NSString *)fullName;
+
+/**
+ *  `fullName` defaults to the contact's default channel value if no name data exists.  This method and its `unformattedPhoneNumber`
+ *   parameter allow the caller to specify formatted or non-formatted phone number for that fall back.
+ */
+- (nullable NSString *)fullNameUsingUnformattedPhoneNumberValue:(BOOL)unformattedPhoneNumber;
+
 - (nullable NSString *) initials;
 
 /**

--- a/Pod/Classes/Models/ZNGContact/ZNGContact.m
+++ b/Pod/Classes/Models/ZNGContact/ZNGContact.m
@@ -298,39 +298,49 @@ static NSString * const ParameterNameClosed = @"is_closed";
     return nil;
 }
 
-- (NSString *)fullName
+- (NSString *)fullNameUsingUnformattedPhoneNumberValue:(BOOL)unformattedPhoneNumber
 {
-    NSString *title = [self titleFieldValue].value;
-    NSString *firstName = [self firstNameFieldValue].value;
-    NSString *lastName = [self lastNameFieldValue].value;
+    NSString *title = [[self titleFieldValue] value];
+    NSString *firstName = [[self firstNameFieldValue] value];
+    NSString *lastName = [[self lastNameFieldValue] value];
     
-    if(firstName.length < 1 && lastName.length < 1)
-    {
-        NSString *phoneNumber = [self phoneNumberChannel].formattedValue;
-        if (phoneNumber) {
-            return phoneNumber;
-        } else {
-            return @"Anonymous User";
-        }
-    }
-    else
-    {
-        NSString *name = @"";
+    if ([firstName length] + [lastName length] == 0) {
+        ZNGChannel * phoneChannel = [self phoneNumberChannel];
         
-        if(title.length > 0)
-        {
-            name = [name stringByAppendingString:[NSString stringWithFormat:@"%@ ", title]];
+        if (phoneChannel != nil) {
+            if (unformattedPhoneNumber) {
+                return [phoneChannel displayValueUsingRawValue];
+            }
+            
+            return [phoneChannel displayValueUsingFormattedValue];
         }
-        if(firstName.length > 0)
+
+        return @"Anonymous User";
+    } else {
+        NSMutableString * name = [[NSMutableString alloc] init];
+        
+        if ([title length] > 0)
         {
-            name = [name stringByAppendingString:[NSString stringWithFormat:@"%@ ", firstName]];
+            [name appendFormat:@"%@ ", title];
         }
-        if(lastName.length > 0)
+        
+        if ([firstName length] > 0)
         {
-            name = [name stringByAppendingString:lastName];
+            [name appendFormat:@"%@ ", firstName];
         }
+        
+        if ([lastName length] > 0)
+        {
+            [name appendString:lastName];
+        }
+        
         return [name stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
     }
+}
+
+- (NSString *)fullName
+{
+    return [self fullNameUsingUnformattedPhoneNumberValue:NO];
 }
 
 - (NSString *) initials

--- a/Pod/Classes/UI/Controllers/ZNGInboxViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGInboxViewController.m
@@ -599,8 +599,10 @@ static NSString * const AssignmentSwipeActionUIType = @"inbox swipe action";
     [refreshUnconfirmedTimers removeObjectForKey:indexPath];
     
     if (contact != nil) {
+        ZNGChannel * phoneChannel = [contact phoneNumberChannel];
+        BOOL shouldUseUnformattedChannelForDisplay = [self.session.service shouldDisplayRawValueForChannel:phoneChannel];
+        cell.contactName.text = [contact fullNameUsingUnformattedPhoneNumberValue:shouldUseUnformattedChannelForDisplay];
         
-        cell.contactName.text = [contact fullName];
         NSUInteger lastMessageAttachmentCount = [contact.lastMessage.attachments count];
         
         if ([contact.lastMessage.body length] > 0) {


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-848

The inbox now uses the same logic as the conversation views when determining whether to display a locally formatted phone number value or the full, unformatted phone number (for non-local phone numbers).

![tweetable-smarty-giff-2](https://user-images.githubusercontent.com/1328743/40517632-244922b6-5f6b-11e8-9a6a-54c23b02af40.gif)
