### PR TITLE
IOS-853: Use unconfirmed_at instead of last message time if possible

### DIFF
--- a/Pod/Classes/Models/ZNGContact/ZNGContact.h
+++ b/Pod/Classes/Models/ZNGContact/ZNGContact.h
@@ -44,6 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong, nullable) NSString * assignedToUserId;
 @property(nonatomic, strong, nullable) NSDate* createdAt;
 @property(nonatomic, strong, nullable) NSDate* updatedAt;
+@property(nonatomic, strong, nullable) NSDate* unconfirmedAt;
 @property(nonatomic, strong, nullable) NSURL * avatarUri;
 
 @property (nonatomic, weak, nullable) ZNGContactClient * contactClient;
@@ -149,7 +150,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Returns a date, after which, this contact will be highlighted as "urgent" if still unconfirmed.
  */
-- (NSDate *) lateUnconfirmedTime;
+- (nullable NSDate *) lateUnconfirmedTime;
 
 #pragma mark - Mutators
 - (void) confirm;

--- a/Pod/Classes/Models/ZNGContact/ZNGContact.m
+++ b/Pod/Classes/Models/ZNGContact/ZNGContact.m
@@ -28,6 +28,7 @@ static NSString * const ParameterNameStarred = @"is_starred";
 static NSString * const ParameterNameConfirmed = @"is_confirmed";
 static NSString * const ParameterNameClosed = @"is_closed";
 
+static const NSTimeInterval LateTimeSeconds = 5.0 * 60.0;  // How long before an unconfirmed contact is 'late' (five minutes)
 
 @implementation ZNGContact
 
@@ -569,7 +570,7 @@ static NSString * const ParameterNameClosed = @"is_closed";
         return nil;
     }
     
-    return [lateDate dateByAddingTimeInterval:(5.0 * 60.0)];
+    return [lateDate dateByAddingTimeInterval:LateTimeSeconds];
 }
 
 #pragma mark - Mutators

--- a/Pod/Classes/Models/ZNGContact/ZNGContact.m
+++ b/Pod/Classes/Models/ZNGContact/ZNGContact.m
@@ -136,7 +136,8 @@ static NSString * const ParameterNameClosed = @"is_closed";
              NSStringFromSelector(@selector(assignedToUserId)): @"assigned_to_user_id",
              @"createdAt" : @"created_at",
              @"updatedAt" : @"updated_at",
-             NSStringFromSelector(@selector(avatarUri)) : @"avatar_uri"
+             NSStringFromSelector(@selector(avatarUri)) : @"avatar_uri",
+             NSStringFromSelector(@selector(unconfirmedAt)): @"unconfirmed_at",
              };
 }
 
@@ -190,6 +191,11 @@ static NSString * const ParameterNameClosed = @"is_closed";
 }
 
 + (NSValueTransformer*)updatedAtJSONTransformer
+{
+    return [ZingleValueTransformers dateValueTransformer];
+}
+
++ (NSValueTransformer *)unconfirmedAtJSONTransformer
 {
     return [ZingleValueTransformers dateValueTransformer];
 }
@@ -555,7 +561,15 @@ static NSString * const ParameterNameClosed = @"is_closed";
 
 - (NSDate *) lateUnconfirmedTime
 {
-    return [self.lastMessage.createdAt dateByAddingTimeInterval:(5.0 * 60.0)];
+    // If the API is up to date and has the newer unconfirmed_at date, use that; otherwise default to
+    //  the old behavior and use the timestamp of the last message
+    NSDate * lateDate = self.unconfirmedAt ?: self.lastMessage.createdAt;
+    
+    if (lateDate == nil) {
+        return nil;
+    }
+    
+    return [lateDate dateByAddingTimeInterval:(5.0 * 60.0)];
 }
 
 #pragma mark - Mutators


### PR DESCRIPTION
The lateness (dot color) for inbox selection (team/person/my inbox menu) did not match the logic for the inbox itself (dot next to each contact name).  The inbox will now use the new `unconfirmed_at` value to match the new inbox selection behavior.

![d6e6db4c0228e122297c0b99a77510a4](https://user-images.githubusercontent.com/1328743/40800073-2dd78f08-64c4-11e8-8e79-f8857d9e4a32.jpg)
