### PR TITLE
Off by one mistake when recovering from a crash

### DIFF
--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
@@ -644,7 +644,7 @@ NSString * const ZNGInboxDataSetSortDirectionDescending = @"desc";
         
         if (!simpleReorderingOrRefresh) {
             // Sanity check
-            if ((overlapRangeInTotalData.location + overlapRangeInTotalData.length) > [mutableContacts count]) {
+            if ((overlapRangeInTotalData.location + overlapRangeInTotalData.length) >= [mutableContacts count]) {
                 SBLogWarning(@"New inbox data overlap range is out of bounds.  Help.  Refreshing all data.");
                 [self refresh];
                 return;


### PR DESCRIPTION
I suddenly realize why this crash still happens and always seems to be an overflow of exactly one.

![giphy](https://user-images.githubusercontent.com/1328743/42788887-107dc8ec-8917-11e8-87fa-b1d78926c0b8.gif)
