### PR TITLE
Refactor logic to find api/auth/socket paths

### DIFF
--- a/Example/Tests/TestURLParsing.m
+++ b/Example/Tests/TestURLParsing.m
@@ -14,7 +14,7 @@ static NSString * const ProductionAuthPath = @"https://app.zingle.me/auth";
 static NSString * const ProductionSocketPath = @"https://socket.zingle.me/";
 static NSString * const CiApiPath = @"https://ci-api.zingle.me/v1";
 static NSString * const CiAuthPath = @"https://ci-app.zingle.me/auth";
-static NSString * const CISocketPath = @"https://ci-app.zingle.me:8000/";
+static NSString * const CiSocketPath = @"https://ci-app.zingle.me:8000/";
 static NSString * const NonZinglePath = @"https://something-else.clownpenis.fart/";
 
 @interface TestURLParsing : XCTestCase
@@ -93,7 +93,7 @@ static NSString * const NonZinglePath = @"https://something-else.clownpenis.fart
 - (void) testCiSocketPathFromApiPath
 {
     NSURL * apiUrl = [NSURL URLWithString:CiApiPath];
-    NSURL * expectedSocketUrl = [NSURL URLWithString:CISocketPath];
+    NSURL * expectedSocketUrl = [NSURL URLWithString:CiSocketPath];
     
     XCTAssertEqualObjects([apiUrl socketUrl], expectedSocketUrl, @"`socketUrl` from API URL should produce %@", expectedSocketUrl);
 }

--- a/Example/Tests/TestURLParsing.m
+++ b/Example/Tests/TestURLParsing.m
@@ -23,21 +23,21 @@ static NSString * const NonZinglePath = @"https://something-else.clownpenis.fart
 
 @implementation TestURLParsing
 
-- (void) testProductionAPIURL
+- (void) testProductionApiUrl
 {
     NSURL * url = [NSURL URLWithString:ProductionApiPath];
     NSString * prefix = [url zingleServerPrefix];
     XCTAssertEqualObjects(prefix, @"", @"Server prefix for api.zingle.me should return an empty string");
 }
 
-- (void) testCIAPIURL
+- (void) testCiApiUrl
 {
     NSURL * url = [NSURL URLWithString:CiApiPath];
     NSString * prefix = [url zingleServerPrefix];
     XCTAssertEqualObjects(prefix, @"ci", @"Server prefix for qa-api.zingle.me should be \"qa\"");
 }
 
-- (void) testProductionComplexURL
+- (void) testProductionComplexUrl
 {
     NSString * path = @"https://api.zingle.me/things/stuff?moreThings=please";
     NSURL * url = [NSURL URLWithString:path];
@@ -45,7 +45,7 @@ static NSString * const NonZinglePath = @"https://something-else.clownpenis.fart
     XCTAssertEqualObjects(prefix, @"", @"Server prefix for api.zingle.me, even with additional path information and a query string, should return an empty string");
 }
 
-- (void) testNonZingleURLReturnsNil
+- (void) testNonZingleUrlReturnsNil
 {
     NSURL * url = [NSURL URLWithString:NonZinglePath];
     NSString * prefix = [url zingleServerPrefix];

--- a/Example/Tests/TestURLParsing.m
+++ b/Example/Tests/TestURLParsing.m
@@ -9,6 +9,14 @@
 #import <XCTest/XCTest.h>
 #import "NSURL+Zingle.h"
 
+static NSString * const ProductionApiPath = @"https://api.zingle.me/v1";
+static NSString * const ProductionAuthPath = @"https://app.zingle.me/auth";
+static NSString * const ProductionSocketPath = @"https://socket.zingle.me/";
+static NSString * const CiApiPath = @"https://ci-api.zingle.me/v1";
+static NSString * const CiAuthPath = @"https://ci-app.zingle.me/auth";
+static NSString * const CISocketPath = @"https://ci-app.zingle.me:8000/";
+static NSString * const NonZinglePath = @"https://something-else.clownpenis.fart/";
+
 @interface TestURLParsing : XCTestCase
 
 @end
@@ -17,18 +25,16 @@
 
 - (void) testProductionAPIURL
 {
-    NSString * path = @"https://api.zingle.me/";
-    NSURL * url = [NSURL URLWithString:path];
+    NSURL * url = [NSURL URLWithString:ProductionApiPath];
     NSString * prefix = [url zingleServerPrefix];
     XCTAssertEqualObjects(prefix, @"", @"Server prefix for api.zingle.me should return an empty string");
 }
 
-- (void) testQAAPIURL
+- (void) testCIAPIURL
 {
-    NSString * path = @"https://qa-api.zingle.me/";
-    NSURL * url = [NSURL URLWithString:path];
+    NSURL * url = [NSURL URLWithString:CiApiPath];
     NSString * prefix = [url zingleServerPrefix];
-    XCTAssertEqualObjects(prefix, @"qa", @"Server prefix for qa-api.zingle.me should be \"qa\"");
+    XCTAssertEqualObjects(prefix, @"ci", @"Server prefix for qa-api.zingle.me should be \"qa\"");
 }
 
 - (void) testProductionComplexURL
@@ -41,10 +47,55 @@
 
 - (void) testNonZingleURLReturnsNil
 {
-    NSString * path = @"https://something-else.clownpenis.fart/";
-    NSURL * url = [NSURL URLWithString:path];
+    NSURL * url = [NSURL URLWithString:NonZinglePath];
     NSString * prefix = [url zingleServerPrefix];
     XCTAssertNil(prefix, @"Server prefix for a non-Zingle URL should return nil");
+}
+
+- (void) testApiPathIdentity
+{
+    NSURL * url = [NSURL URLWithString:ProductionApiPath];
+    XCTAssertEqualObjects(url, [url apiUrlV1], @"Calling `apiUrlV1` should be an identity operation on a v1 API URL");
+}
+
+- (void) testNonZingleUrlProducesNilZinglePaths
+{
+    NSURL * url = [NSURL URLWithString:NonZinglePath];
+    XCTAssertNil([url apiUrlV1], @"Non-Zingle path should produce nil API path");
+    XCTAssertNil([url authUrl], @"Non-Zingle path should produce nil auth path");
+    XCTAssertNil([url socketUrl], @"Non-Zingle path should produce nil socket path");
+}
+
+- (void) testProductionAuthPathFromApiPath
+{
+    NSURL * apiUrl = [NSURL URLWithString:ProductionApiPath];
+    NSURL * expectedAuthUrl = [NSURL URLWithString:ProductionAuthPath];
+    
+    XCTAssertEqualObjects([apiUrl authUrl], expectedAuthUrl, @"Calling `authUrl` should return the coresponding auth URL from the production API URL");
+}
+
+ - (void) testProductionSocketUrlFromApi
+{
+    NSURL * apiUrl = [NSURL URLWithString:ProductionApiPath];
+    NSURL * expectedSocketUrl = [NSURL URLWithString:ProductionSocketPath];
+    
+    XCTAssertEqualObjects([apiUrl socketUrl], expectedSocketUrl, @"`socketUrl` from API URL should produce %@", expectedSocketUrl);
+}
+
+- (void) testCiAuthPathFromApiPath
+{
+    NSURL * apiUrl = [NSURL URLWithString:CiApiPath];
+    NSURL * expectedAuthUrl = [NSURL URLWithString:CiAuthPath];
+    
+    XCTAssertEqualObjects([apiUrl authUrl], expectedAuthUrl, @"Calling `authUrl` should return the coresponding auth URL from the CI API URL");
+}
+
+- (void) testCiSocketPathFromApiPath
+{
+    NSURL * apiUrl = [NSURL URLWithString:CiApiPath];
+    NSURL * expectedSocketUrl = [NSURL URLWithString:CISocketPath];
+    
+    XCTAssertEqualObjects([apiUrl socketUrl], expectedSocketUrl, @"`socketUrl` from API URL should produce %@", expectedSocketUrl);
 }
 
 @end

--- a/Example/Tests/TestURLParsing.m
+++ b/Example/Tests/TestURLParsing.m
@@ -10,9 +10,11 @@
 #import "NSURL+Zingle.h"
 
 static NSString * const ProductionApiPath = @"https://api.zingle.me/v1";
+static NSString * const ProductionApiV2Path = @"https://api.zingle.me/v2";
 static NSString * const ProductionAuthPath = @"https://app.zingle.me/auth";
 static NSString * const ProductionSocketPath = @"https://socket.zingle.me/";
 static NSString * const CiApiPath = @"https://ci-api.zingle.me/v1";
+static NSString * const CiApiV2Path = @"https://ci-api.zingle.me/v2";
 static NSString * const CiAuthPath = @"https://ci-app.zingle.me/auth";
 static NSString * const CiSocketPath = @"https://ci-app.zingle.me:8000/";
 static NSString * const NonZinglePath = @"https://something-else.clownpenis.fart/";
@@ -56,6 +58,17 @@ static NSString * const NonZinglePath = @"https://something-else.clownpenis.fart
 {
     NSURL * url = [NSURL URLWithString:ProductionApiPath];
     XCTAssertEqualObjects(url, [url apiUrlV1], @"Calling `apiUrlV1` should be an identity operation on a v1 API URL");
+}
+
+- (void) testV2ApiPathFromV1
+{
+    NSURL * v1Url = [NSURL URLWithString:ProductionApiPath];
+    NSURL * expectedV2Url = [NSURL URLWithString:ProductionApiV2Path];
+    XCTAssertEqualObjects([v1Url apiUrlV2], expectedV2Url, @"Production V2 API URL should be calculable from V1");
+    
+    NSURL * ciV1Url = [NSURL URLWithString:CiApiPath];
+    NSURL * expectedCiV2Url = [NSURL URLWithString:CiApiV2Path];
+    XCTAssertEqualObjects([ciV1Url apiUrlV2], expectedCiV2Url, @"CI V2 API URL should be calculable from V1");
 }
 
 - (void) testNonZingleUrlProducesNilZinglePaths

--- a/Pod/Classes/Clients/NSURL+Zingle.h
+++ b/Pod/Classes/Clients/NSURL+Zingle.h
@@ -17,6 +17,21 @@
  *  In the case of a production Zingle URL with no prefix, such as "https://secure.zingle.me/" this will return an empty string
  *  In the case of a non-Zingle URL such as "https://thing-stuff-place.something.poop" this will return nil
  */
-- (NSString *)zingleServerPrefix;
+- (NSString * _Nullable)zingleServerPrefix;
+
+/**
+ *  Returns the v1 API URL corresponding to the current Zingle URL.  Nil if the current URL does not appear to be a Zingle URL.
+ */
+- (NSURL * _Nullable) apiUrlV1;
+
+/**
+ *  Returns the secure auth URL corresponding to the current Zingle URL.  Nil if the current URL does not appear to be a Zingle URL.
+ */
+- (NSURL * _Nullable) authUrl;
+
+/**
+ *  Returns the socket URL corresponding to the current Zingle URL.  Nil if the current URL does not appear to be a Zingle URL.
+ */
+- (NSURL * _Nullable) socketUrl;
 
 @end

--- a/Pod/Classes/Clients/NSURL+Zingle.h
+++ b/Pod/Classes/Clients/NSURL+Zingle.h
@@ -22,16 +22,21 @@
 /**
  *  Returns the v1 API URL corresponding to the current Zingle URL.  Nil if the current URL does not appear to be a Zingle URL.
  */
-- (NSURL * _Nullable) apiUrlV1;
+- (NSURL * _Nullable)apiUrlV1;
+
+/**
+ *  Returns the v2 API URL corresponding to the current Zingle URL.  Nil if the current URL does not appear to be a Zingle URL.
+ */
+- (NSURL * _Nullable)apiUrlV2;
 
 /**
  *  Returns the secure auth URL corresponding to the current Zingle URL.  Nil if the current URL does not appear to be a Zingle URL.
  */
-- (NSURL * _Nullable) authUrl;
+- (NSURL * _Nullable)authUrl;
 
 /**
  *  Returns the socket URL corresponding to the current Zingle URL.  Nil if the current URL does not appear to be a Zingle URL.
  */
-- (NSURL * _Nullable) socketUrl;
+- (NSURL * _Nullable)socketUrl;
 
 @end

--- a/Pod/Classes/Clients/NSURL+Zingle.m
+++ b/Pod/Classes/Clients/NSURL+Zingle.m
@@ -50,6 +50,18 @@
     return [NSURL URLWithString:path];
 }
 
+- (NSURL * _Nullable)apiUrlV2
+{
+    NSString * prefix = [self zingleServerPrefix];
+    
+    if (prefix == nil) {
+        return nil;
+    }
+    
+    NSString * path = ([prefix length] > 0) ? [NSString stringWithFormat:@"https://%@-api.zingle.me/v2", prefix] : @"https://api.zingle.me/v2";
+    return [NSURL URLWithString:path];
+}
+
 - (NSURL * _Nullable)authUrl
 {
     NSString * prefix = [self zingleServerPrefix];

--- a/Pod/Classes/Clients/NSURL+Zingle.m
+++ b/Pod/Classes/Clients/NSURL+Zingle.m
@@ -38,5 +38,51 @@
     return [path substringWithRange:prefixRange];
 }
 
+- (NSURL * _Nullable)apiUrlV1
+{
+    NSString * prefix = [self zingleServerPrefix];
+    
+    if (prefix == nil) {
+        return nil;
+    }
+    
+    NSString * path = ([prefix length] > 0) ? [NSString stringWithFormat:@"https://%@-api.zingle.me/v1", prefix] : @"https://api.zingle.me/v1";
+    return [NSURL URLWithString:path];
+}
+
+- (NSURL * _Nullable)authUrl
+{
+    NSString * prefix = [self zingleServerPrefix];
+    
+    if (prefix == nil) {
+        return nil;
+    }
+    
+    if ([prefix length] == 0) {
+        // Empty string means production (per `zingleServerPrefix` documentation)
+        return [NSURL URLWithString:@"https://app.zingle.me/auth"];
+    }
+    
+    // We have a non-production prefix
+    NSString * path = [NSString stringWithFormat:@"https://%@-app.zingle.me/auth", prefix];
+    return [NSURL URLWithString:path];
+}
+
+- (NSURL *)socketUrl
+{
+    NSString * prefix = [self zingleServerPrefix];
+    
+    if (prefix == nil) {
+        return nil;
+    }
+    
+    if ([prefix length] == 0) {
+        return [NSURL URLWithString:@"https://socket.zingle.me/"];
+    }
+    
+    // We have a non-production prefix
+    NSString * path = [NSString stringWithFormat:@"https://%@-app.zingle.me:8000/", prefix];
+    return [NSURL URLWithString:path];
+}
 
 @end

--- a/Pod/Classes/ZingleSession.m
+++ b/Pod/Classes/ZingleSession.m
@@ -17,6 +17,7 @@
 #import <objc/runtime.h>
 #import "ZNGImageSizeCache.h"
 #import <UserNotifications/UserNotifications.h>
+#import "NSURL+Zingle.h"
 
 @import SBObjectiveCWrapper;
 
@@ -163,11 +164,11 @@ void __userNotificationWillPresent(id self, SEL _cmd, id notificationCenter, id 
         
         _jsonProcessingQueue = dispatch_queue_create("com.zingleme.sdk.jsonProcessing", NULL);
         
-        _sessionManager = [[self class] anonymousSessionManagerWithURL:[NSURL URLWithString:self.urlString]];
+        NSURL * v1Url = [[NSURL URLWithString:self.urlString] apiUrlV1];
+        _sessionManager = [[self class] anonymousSessionManagerWithURL:v1Url];
         [_sessionManager.requestSerializer setAuthorizationHeaderFieldWithUsername:token password:key];
         
-        NSString * v2ApiPath = [self.urlString stringByReplacingOccurrencesOfString:@"v1" withString:@"v2"];
-        _v2SessionManager = [[self class] anonymousSessionManagerWithURL:[NSURL URLWithString:v2ApiPath]];
+        _v2SessionManager = [[self class] anonymousSessionManagerWithURL:[v1Url apiUrlV2]];
         [_v2SessionManager.requestSerializer setAuthorizationHeaderFieldWithUsername:token password:key];
         
         self.accountClient = [[ZNGAccountClient alloc] initWithSession:self];
@@ -214,8 +215,7 @@ void __userNotificationWillPresent(id self, SEL _cmd, id notificationCenter, id 
         [[ZNGAnalytics sharedAnalytics] setZingleURL:url];
         [_sessionManager.requestSerializer setAuthorizationHeaderFieldWithUsername:self.token password:self.key];
         
-        NSString * v2Path = [urlString stringByReplacingOccurrencesOfString:@"v1" withString:@"v2"];
-        self.v2SessionManager = [[self class] anonymousSessionManagerWithURL:[NSURL URLWithString:v2Path]];
+        self.v2SessionManager = [[self class] anonymousSessionManagerWithURL:[url apiUrlV2]];
         [_v2SessionManager.requestSerializer setAuthorizationHeaderFieldWithUsername:self.token password:self.key];
     }
 }


### PR DESCRIPTION
- Put all of that code into `NSURL+Zingle` where we previously extracted the instance prefix but left forming the specific URLs up to the caller
- Add unit tests
- Become confused by how the same production auth path no longer works after the refactor even though requests going out over the wire look identical
- Become terrified when changing from `secure.zingle.me/auth` to `app.zingle.me/auth` magically fixes the problem.  I intended to make this same change after verifying that the old behavior worked after the refactor.
- Close your eyes, take a shower, and move on with your life

![giphy](https://user-images.githubusercontent.com/1328743/61158661-7d011b00-a4ae-11e9-8b15-5d6f3af6bd90.gif)



