### PR TITLE
Added a new network status for connected-to-non-production

### DIFF
--- a/Pod/Classes/NetworkDiagnostics/ZNGNetworkLookout.h
+++ b/Pod/Classes/NetworkDiagnostics/ZNGNetworkLookout.h
@@ -17,6 +17,7 @@ typedef enum {
     ZNGNetworkStatusInternetUnreachable,
     ZNGNetworkStatusZingleAPIUnreachable,
     ZNGNetworkStatusZingleSocketDisconnected,
+    ZNGNetworkStatusConnectedToDevelopmentInstance,
     ZNGNetworkStatusConnected
 } ZNGNetworkLookoutStatus;
 

--- a/Pod/Classes/UI/Categories/UILabel+NetworkStatus.m
+++ b/Pod/Classes/UI/Categories/UILabel+NetworkStatus.m
@@ -14,6 +14,11 @@
 - (void) updateWithNetworkStatus:(ZNGNetworkLookoutStatus)status
 {
     switch (status) {
+        case ZNGNetworkStatusConnectedToDevelopmentInstance:
+            self.backgroundColor = [UIColor zng_lightBlue];
+            self.text = @"This is a non-production server instance. 🤡";
+            return;
+            
         case ZNGNetworkStatusUnknown:
         case ZNGNetworkStatusConnected:
             self.text = nil;


### PR DESCRIPTION
This allows usage of the network troubleshooting banner to show that the build is a non-production build.

![lead_400_10844_](https://user-images.githubusercontent.com/1328743/61986416-df384080-afc3-11e9-8f3c-88c16df809c9.gif)
