### PR TITLE
TECH-11983: Fixed two issues breaking socket service handshake

### DIFF
--- a/Example/Tests/TestURLParsing.m
+++ b/Example/Tests/TestURLParsing.m
@@ -71,6 +71,16 @@ static NSString * const NonZinglePath = @"https://something-else.clownpenis.fart
     XCTAssertEqualObjects([ciV1Url apiUrlV2], expectedCiV2Url, @"CI V2 API URL should be calculable from V1");
 }
 
+- (void) testApiPathsFromPrefixedSocketPath
+{
+    NSURL * socketUrl = [NSURL URLWithString:CiSocketPath];
+    NSURL * expectedV1ApiUrl = [NSURL URLWithString:CiApiPath];
+    NSURL * expectedV2ApiUrl = [NSURL URLWithString:CiApiV2Path];
+    
+    XCTAssertEqualObjects([socketUrl apiUrlV1], expectedV1ApiUrl, @"CI V1 API URL should be calculable from socket URL %@", CiSocketPath);
+    XCTAssertEqualObjects([socketUrl apiUrlV2], expectedV2ApiUrl, @"CI V2 API URL should be calculable from socket URL %@", CiSocketPath);
+}
+
 - (void) testNonZingleUrlProducesNilZinglePaths
 {
     NSURL * url = [NSURL URLWithString:NonZinglePath];

--- a/Pod/Classes/Clients/NSURL+Zingle.m
+++ b/Pod/Classes/Clients/NSURL+Zingle.m
@@ -12,9 +12,10 @@
 
 - (NSString *)zingleServerPrefix
 {
-    NSString * path = self.absoluteString;
-    NSRegularExpression * regex = [NSRegularExpression regularExpressionWithPattern:@"^(https?:\\/\\/)?((\\w+)-)?\\w+.zingle.me(\\/.*)?$" options:NSRegularExpressionCaseInsensitive error:nil];
-    NSArray<NSTextCheckingResult *> * matches = [regex matchesInString:path options:0 range:NSMakeRange(0, [path length])];
+    NSURLComponents * components = [NSURLComponents componentsWithURL:self resolvingAgainstBaseURL:YES];
+    NSString * host = components.host;
+    NSRegularExpression * regex = [NSRegularExpression regularExpressionWithPattern:@"^((\\w+)-)?\\w+.zingle.me$" options:NSRegularExpressionCaseInsensitive error:nil];
+    NSArray<NSTextCheckingResult *> * matches = [regex matchesInString:host options:0 range:NSMakeRange(0, [host length])];
     NSTextCheckingResult * match = [matches firstObject];
     
     if (match == nil) {
@@ -22,20 +23,20 @@
         return nil;
     }
     
-    if (match.numberOfRanges < 4) {
-        // We did not find capture group 3.  This indicates a production Zingle URL with no prefix.
+    if (match.numberOfRanges < 3) {
+        // We did not find capture group 2.  This indicates a production Zingle URL with no prefix.
         return @"";
     }
     
     // We found a prefix.  Return it.
-    NSRange prefixRange = [match rangeAtIndex:3];
+    NSRange prefixRange = [match rangeAtIndex:2];
     
     if (prefixRange.location == NSNotFound) {
-        // We did not find capture group 3.  This indicates a production Zingle URL with no prefix.
+        // We did not find capture group 2.  This indicates a production Zingle URL with no prefix.
         return @"";
     }
     
-    return [path substringWithRange:prefixRange];
+    return [host substringWithRange:prefixRange];
 }
 
 - (NSURL * _Nullable)apiUrlV1

--- a/Pod/Classes/Clients/ZNGSocketClient.m
+++ b/Pod/Classes/Clients/ZNGSocketClient.m
@@ -73,13 +73,6 @@
 - (void) connect
 {
     [self _connectSocket];
-}
-
-- (void) _authenticateAndConnect
-{
-    SBLogVerbose(@"Request session cookie through a POST...");
-
-    [self _connectSocket];
     [self _uncoverNumericIdForCurrentService];
 }
 


### PR DESCRIPTION
https://zingle.atlassian.net/browse/TECH-11983

- V2 API URL was being parsed incorrectly from a socket URL with a non-default port.  Added a unit test to reproduce this and updated the URL parsing logic to ignore port.  This bug caused the socket client to be unable to subscribe to service updates.
- After fixing the above, the code to uncover numeric IDs from socket was dead after the JWT refactor.  It has been shocked back into life.

![live](https://thumbs.gfycat.com/ImmaterialBraveChevrotain-size_restricted.gif)
