### PR TITLE
IOS-926: Calendar events cause contact refresh

### DIFF
--- a/Pod/Classes/Models/ZNGContact/ZNGContact.m
+++ b/Pod/Classes/Models/ZNGContact/ZNGContact.m
@@ -117,6 +117,10 @@ static const NSTimeInterval LateTimeSeconds = 5.0 * 60.0;  // How long before an
     if (![self.assignedToTeamId isEqualToString:contact.assignedToTeamId]) {
         self.assignedToTeamId = contact.assignedToTeamId;
     }
+    
+    if (![self.calendarEvents isEqualToArray:contact.calendarEvents]) {
+        self.calendarEvents = contact.calendarEvents;
+    }
 }
 
 #pragma mark - Mantle


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-926

The logic to determine whether a contact has been changed since we last saw it was not considering calendar events.  Silly contact.

![145f574fe83b8f407878fa90def05010](https://user-images.githubusercontent.com/1328743/62171943-934c0b00-b2e5-11e9-92b6-041c5a22cc26.gif)
