### PR TITLE
IOS-908: Switch from using login name to username for analytics

### DIFF
--- a/Pod/Classes/ZingleAccountSession.m
+++ b/Pod/Classes/ZingleAccountSession.m
@@ -593,7 +593,7 @@ NSString * const ZingleFeedListShouldBeRefreshedNotification = @"ZingleFeedListS
     [self.userAuthorizationClient userAuthorizationWithSuccess:^(ZNGUserAuthorization * theUserAuthorization, ZNGStatus *status) {
         self.userAuthorization = theUserAuthorization;
         
-        [[ZNGAnalytics sharedAnalytics] trackLoginSuccessWithToken:self.token andUserAuthorizationObject:theUserAuthorization];
+        [[ZNGAnalytics sharedAnalytics] trackLoginSuccessWithToken:theUserAuthorization.username andUserAuthorizationObject:theUserAuthorization];
         dispatch_semaphore_signal(semaphore);
     } failure:^(ZNGError *error) {
         SBLogError(@"Unable to retrieve current user info from the root URL: %@", error);


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-908

SSO users may not have a login name per se.

![ce35e25863e63a58f1f45f6654db79a2_w200](https://user-images.githubusercontent.com/1328743/62335474-c8409500-b480-11e9-9061-71797b33c7d0.gif)
