### PR TITLE
IOS-935: Fully recover socket connection after interruption

### DIFF
--- a/Pod/Classes/Clients/ZNGSocketClient.m
+++ b/Pod/Classes/Clients/ZNGSocketClient.m
@@ -247,6 +247,7 @@
 - (void) socketDidConnectWithData:(NSArray *)data ackEmitter:(SocketAckEmitter *)ackEmitter
 {
     SBLogInfo(@"Web socket connected.");
+    controllerIsBound = NO;
     [self _bindNodeController];
 }
 


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-935

Socket client was not rebinding after reconnecting due to improper retention of the relevant flag.

![giphy](https://user-images.githubusercontent.com/1328743/62487365-76488980-b776-11e9-856a-e7b4361e4958.gif)
