### PR TITLE
IOS-918: Stop angering auto layout when compensating for an iOS text field bug

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -1905,14 +1905,13 @@ enum ZNGConversationSections
     UITextView * textView = self.inputToolbar.contentView.textView;
     
     // Use the attributed text to preserve any image attachments
-    NSAttributedString * newAttributedText = [[NSAttributedString alloc] initWithString:text];
+    // Note that the font needs to be manually applied via NSAttributedString or else the font of the text field
+    //  forever changes.
+    UIFont * font = textView.font;
+    NSAttributedString * newAttributedText = [[NSAttributedString alloc] initWithString:text attributes:@{NSFontAttributeName: font}];
     NSMutableAttributedString * attributedText = [textView.attributedText mutableCopy];
     [attributedText appendAttributedString:newAttributedText];
-    
-    // Font must be manually preserved when the text is changed to avoid a UIKit bug
-    UIFont * font = textView.font;
     textView.attributedText = attributedText;
-    textView.font = font;
     
     [self.inputToolbar toggleSendButtonEnabled];
     [self.inputToolbar collapseInputButtons];


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-918

The original iOS bug: https://stackoverflow.com/questions/21742376/nsattributedstring-changed-font-unexpectedly-after-inserting-image

The old fix recorded the text field's font and set it back to normal after adding attributed text.  This caused a race condition in iOS 12, especially with smaller devices, that could cause unresolvable and permanent layout conflicts.  The end result was the text field staying massive forever and no longer resizing.

![giphy](https://user-images.githubusercontent.com/1328743/62492429-726f3400-b783-11e9-82e5-a2c1222c97b6.gif)
