### PR TITLE
IOS-892: Fix mixed detection of changing channel if non-message events exist in between

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -1170,12 +1170,12 @@ enum ZNGConversationSections
         return NO;
     }
     
-    ZNGEvent * event = [[self eventViewModelAtIndexPath:indexPath] event];
-    ZNGEvent * priorEvent = [self.conversation priorEvent:event];
+    ZNGMessage * message = [[[self eventViewModelAtIndexPath:indexPath] event] message];
+    ZNGMessage * priorMessage = [self.conversation priorMessage:message];
     
     // Have channels changed?
-    ZNGChannel * thisChannel = [[event.message contactCorrespondent] channel];
-    ZNGChannel * priorChannel = [[priorEvent.message contactCorrespondent] channel];
+    ZNGChannel * thisChannel = [[message contactCorrespondent] channel];
+    ZNGChannel * priorChannel = [[priorMessage contactCorrespondent] channel];
     
     if ((thisChannel != nil) && (priorChannel != nil) && (![thisChannel isEqual:priorChannel])) {
         // The channel has changed!

--- a/Pod/Classes/UI/ViewModels/Events/ZNGConversation.h
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGConversation.h
@@ -142,6 +142,11 @@ extern NSString * _Nonnull const ZNGConversationParticipantTypeGroup;
 - (nullable ZNGEvent *) priorEvent:(nonnull ZNGEvent *)event;
 
 /**
+ *  Returns the message prior to the provided message or nil if none exists.
+ */
+- (nullable ZNGMessage *) priorMessage:(nonnull ZNGMessage *)message;
+
+/**
  *  Returns the last message sent by the same type of person, meaning this will be the prior message sent by the contact
  *   if the supplied message is sent by a contact.  If it is a service, this will likely be the prior message sent by the
  *   same person as a service, but it may also be a different employee.


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-892

The code to detect when a contact's channel has changed in order to display it in the UI was always failing if a non-message event existed between the message in question and the prior message.

![tenor](https://user-images.githubusercontent.com/1328743/62496728-b0258a00-b78e-11e9-8b93-ef69fdeb3a17.gif)
