### PR TITLE
IOS-949: Use the new JSQMessages subspec to avoid haunted xibs

### DIFF
--- a/ZingleSDK.podspec
+++ b/ZingleSDK.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.dependency 'JVFloatLabeledTextField'  
   s.dependency 'Mantle'
   s.dependency 'SBObjectiveCWrapper'
-  s.dependency 'JSQMessagesViewController'
+  s.dependency 'JSQMessagesViewController/xibs-without-cells'
   s.dependency 'Analytics', '~> 3.0'
   s.dependency 'MGSwipeTableCell'
   s.dependency 'SDWebImage/GIF'


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-949

Hopefully this subspec is temporary and Apple fixes the ibtool crash

![Man-Riding-Smal-Bike](https://user-images.githubusercontent.com/1328743/63187851-baf4e000-c014-11e9-9cc8-a2483fae7060.gif)
