### PR TITLE
Fix warnings in newer versions of Xcode

### DIFF
--- a/Pod/Classes/Clients/ZNGSocketClient.m
+++ b/Pod/Classes/Clients/ZNGSocketClient.m
@@ -69,7 +69,7 @@
 
 - (BOOL) active
 {
-    int status = [socketManager status];
+    int status = (int)[socketManager status];
     return ((status == SocketIOStatusConnected) || (status == SocketIOStatusConnecting));
 }
 

--- a/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
@@ -307,7 +307,7 @@ static void * ZNGConversationKVOContext  =   &ZNGConversationKVOContext;
     
     [self.view addSubview:loadingGradient];
     
-    NSLayoutConstraint * top = [NSLayoutConstraint constraintWithItem:loadingGradient attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.topLayoutGuide attribute:NSLayoutAttributeBottom multiplier:1.0 constant:0.0];
+    NSLayoutConstraint * top = [NSLayoutConstraint constraintWithItem:loadingGradient attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.view.safeAreaLayoutGuide attribute:NSLayoutAttributeTop multiplier:1.0 constant:0.0];
     NSLayoutConstraint * height = [NSLayoutConstraint constraintWithItem:loadingGradient attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:6.0];
     NSLayoutConstraint * left = [NSLayoutConstraint constraintWithItem:loadingGradient attribute:NSLayoutAttributeLeft relatedBy:NSLayoutRelationEqual toItem:self.view attribute:NSLayoutAttributeLeft multiplier:1.0 constant:0.0];
     NSLayoutConstraint * right = [NSLayoutConstraint constraintWithItem:loadingGradient attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:self.view attribute:NSLayoutAttributeRight multiplier:1.0 constant:0.0];
@@ -987,7 +987,7 @@ static void * ZNGConversationKVOContext  =   &ZNGConversationKVOContext;
 #pragma mark - Insets
 - (void) jsq_updateCollectionViewInsets
 {
-    [self jsq_setCollectionViewInsetsTopValue:self.topLayoutGuide.length + self.topContentAdditionalInset
+    [self jsq_setCollectionViewInsetsTopValue:self.view.safeAreaInsets.top + self.topContentAdditionalInset
                                   bottomValue:CGRectGetMaxY(self.collectionView.frame) - CGRectGetMinY(self.inputToolbar.frame) + self.additionalBottomInset];
 }
 

--- a/Pod/Classes/UI/Controllers/ZNGImageAttachmentController.m
+++ b/Pod/Classes/UI/Controllers/ZNGImageAttachmentController.m
@@ -133,7 +133,11 @@
 
 - (void) imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary<NSString *,id> *)info
 {
+    // See comments in `attachImageFromPhotoLibraryWithInfo` below for why we are still using this deprecated functionality
+#pragma diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     if (info[UIImagePickerControllerReferenceURL] != nil) {
+#pragma diagnostic pop
         // This is from the photo library.  We can load it from there.
         [self attachImageFromPhotoLibraryWithInfo:info];
     } else if (info[UIImagePickerControllerOriginalImage] != nil) {
@@ -196,7 +200,10 @@
     //  the PHAsset passed in the image picker callback the very first time it is done.  The alternative is to ask the user for permission
     //  for photo library access up front before an image is selected.  That would avoid a deprecated dictionary key at the expense of a
     //  slightly worse user experience.
+#pragma diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     NSURL * url = info[UIImagePickerControllerReferenceURL];
+#pragma diagnostic pop
     
     if (url == nil) {
         SBLogError(@"The user selected an image, but we did not receieve a reference URL to retrieve it.  Drat.");
@@ -216,8 +223,11 @@
             return;
         }
         
+        #pragma diagnostic push
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         PHAsset * asset = [[PHAsset fetchAssetsWithALAssetURLs:@[url] options:nil] lastObject];
-        
+        #pragma diagnostic pop
+
         if (asset == nil) {
             SBLogError(@"Unable to retrieve the selected image asset from disk.  Odd.");
             [self showImageAttachmentError];

--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -264,7 +264,7 @@ enum ZNGConversationSections
         [self updateForInputLockedStatus:self.conversation.lockedDescription oldStatus:nil];
     });
     
-    NSLayoutConstraint * top = [NSLayoutConstraint constraintWithItem:networkStatusLabel attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.topLayoutGuide attribute:NSLayoutAttributeBottom multiplier:1.0 constant:0.0];
+    NSLayoutConstraint * top = [NSLayoutConstraint constraintWithItem:networkStatusLabel attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.view.safeAreaLayoutGuide attribute:NSLayoutAttributeTop multiplier:1.0 constant:0.0];
     NSLayoutConstraint * left = [NSLayoutConstraint constraintWithItem:networkStatusLabel attribute:NSLayoutAttributeLeft relatedBy:NSLayoutRelationEqual toItem:self.view attribute:NSLayoutAttributeLeft multiplier:1.0 constant:0.0];
     NSLayoutConstraint * right = [NSLayoutConstraint constraintWithItem:networkStatusLabel attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:self.view attribute:NSLayoutAttributeRight multiplier:1.0 constant:0.0];
     [self.view addConstraints:@[top, left, right]];
@@ -1028,7 +1028,7 @@ enum ZNGConversationSections
     bannerContainer.layer.masksToBounds = YES;
     bannerContainer.userInteractionEnabled = NO;
     
-    NSLayoutConstraint * top = [NSLayoutConstraint constraintWithItem:bannerContainer attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.topLayoutGuide attribute:NSLayoutAttributeBottom multiplier:1.0 constant:0.0];
+    NSLayoutConstraint * top = [NSLayoutConstraint constraintWithItem:bannerContainer attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self.view.safeAreaLayoutGuide attribute:NSLayoutAttributeTop multiplier:1.0 constant:0.0];
     NSLayoutConstraint * width = [NSLayoutConstraint constraintWithItem:bannerContainer attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:self.view attribute:NSLayoutAttributeWidth multiplier:1.0 constant:0.0];
     NSLayoutConstraint * left = [NSLayoutConstraint constraintWithItem:bannerContainer attribute:NSLayoutAttributeLeft relatedBy:NSLayoutRelationEqual toItem:self.view attribute:NSLayoutAttributeLeft multiplier:1.0 constant:0.0];
     NSLayoutConstraint * height = [NSLayoutConstraint constraintWithItem:bannerContainer attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:30.0];

--- a/Pod/Classes/UI/ZNGConversation.storyboard
+++ b/Pod/Classes/UI/ZNGConversation.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14854.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="yXX-6h-nLe">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="yXX-6h-nLe">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment version="2304" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14806.4"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -1623,19 +1623,10 @@
                         <viewLayoutGuide key="safeArea" id="6aC-6y-me5"/>
                     </view>
                     <connections>
-                        <outlet property="searchDisplayController" destination="fZB-BA-4Hq" id="aJI-ch-GNB"/>
                         <outlet property="tableView" destination="drN-GY-1hp" id="FXL-Qf-HjD"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="pS7-m0-FYW" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <searchDisplayController id="fZB-BA-4Hq">
-                    <connections>
-                        <outlet property="delegate" destination="X8F-hv-i5R" id="NuM-c7-O90"/>
-                        <outlet property="searchContentsController" destination="X8F-hv-i5R" id="Odh-gp-7Rf"/>
-                        <outlet property="searchResultsDataSource" destination="X8F-hv-i5R" id="vmY-1e-T9F"/>
-                        <outlet property="searchResultsDelegate" destination="X8F-hv-i5R" id="BrJ-Kv-xsS"/>
-                    </connections>
-                </searchDisplayController>
             </objects>
             <point key="canvasLocation" x="2695" y="461"/>
         </scene>

--- a/ZingleSDK.podspec
+++ b/ZingleSDK.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/Zingle/ios-sdk.git", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/zingleme'
 
-  s.platform     = :ios, '10.0'
+  s.platform     = :ios, '11.0'
   s.requires_arc = true
 
   s.source_files = 'Pod/Classes/**/*.{h,m}'


### PR DESCRIPTION
- Replaced some deprecations
- Surrounded one tricky deprecation with compiler flags to ignore #fornow
- Incremented target to iOS 11 to allow later usage of color assets