### PR TITLE
IOS-983: Less spammy JWT refresh

### DIFF
--- a/Pod/Classes/Clients/ZNGJWTClient.m
+++ b/Pod/Classes/Clients/ZNGJWTClient.m
@@ -102,7 +102,11 @@
     AFHTTPSessionManager * authedSession = [session copy];
     [authedSession.requestSerializer setValue:[NSString stringWithFormat:@"Bearer %@", jwt] forHTTPHeaderField:@"Authorization"];
     
+    _requestPending = YES;
+    
     [authedSession GET:@"token/refresh" parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
+        self->_requestPending = NO;
+        
         NSString * jwt = responseObject[@"token"];
         
         if ([jwt length] == 0) {
@@ -123,6 +127,7 @@
         }
     } failure:^(NSURLSessionDataTask * _Nullable task, NSError * _Nonnull error) {
         SBLogError(@"Unable to refresh JWT: %@", [error localizedDescription]);
+        self->_requestPending = NO;
         
         if (failure != nil) {
             failure(error);

--- a/Pod/Classes/ZingleAccountSession.m
+++ b/Pod/Classes/ZingleAccountSession.m
@@ -631,6 +631,8 @@ NSString * const ZingleFeedListShouldBeRefreshedNotification = @"ZingleFeedListS
         
         [self updateStateForNewAccountOrService];
     } failure:^(ZNGError *error) {
+        SBLogError(@"Failed to retrieve accounts: %@", error);
+        self.mostRecentError = error;
         self.availableAccounts = @[];
         self.availableServices = nil;
     }];
@@ -648,6 +650,8 @@ NSString * const ZingleFeedListShouldBeRefreshedNotification = @"ZingleFeedListS
         
         [self updateStateForNewAccountOrService];
     } failure:^(ZNGError *error) {
+        SBLogError(@"Failed to retrieve services: %@", error);
+        self.mostRecentError = error;
         self.availableServices = @[];
     }];
 }


### PR DESCRIPTION
- The `_requestPending` flag was not being set correctly when refreshing a JWT.
- Initial service/account fetches were dodging the normal error handling logic.  This was not intentional and caused a problem while fixing the above.

![tenor](https://user-images.githubusercontent.com/1328743/65274389-0b5dd280-dad8-11e9-89a0-1494678e5fb6.gif)
