### PR TITLE
IOS-986: Add more logging during JWT refresh and fix socket recovery

### DIFF
--- a/Pod/Classes/Clients/ZNGSocketClient.m
+++ b/Pod/Classes/Clients/ZNGSocketClient.m
@@ -268,6 +268,13 @@
         return;
     }
     
+    if (bindRetryCount >= 5) {
+        SBLogWarning(@"No response has been received from bindNodeController in %d tries.  Reconnecting...", (int)bindRetryCount);
+        [self disconnect];
+        [self connect];
+        return;
+    }
+    
     if (bindRetryCount > 0) {
         SBLogInfo(@"Retrying bindNodeController, attempt #%llu", (unsigned long long)bindRetryCount);
     }

--- a/Pod/Classes/ZingleSession.m
+++ b/Pod/Classes/ZingleSession.m
@@ -309,6 +309,8 @@ void __userNotificationWillPresent(id self, SEL _cmd, id notificationCenter, id 
             NSError * error = [NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey: description}];
             completion(nil, error);
         }
+        
+        return;
     }
     
     NSURLComponents * desiredUrlComponents = [NSURLComponents componentsWithURL:self.sessionManager.baseURL resolvingAgainstBaseURL:YES];


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-986

These SDK changes do not actually address the above ticket, but:

1. The logging helped diagnose it
2. Fixing this issue also uncovered an issue that caused socket to forever use an expired JWT and never recover if the app was fully open and active during the entire token lifetime.  The socket connection itself is still alive, but the server silently ignores all `bindNodeController` requests with the old JWT.  This state is likely impossible with real world JWT lifetimes, but this "OK, we've failed five times, let's try a hard reconnect" logic makes socket more robust in general.

![b4002-1ip8omh](https://user-images.githubusercontent.com/1328743/65735580-ccf28580-e08c-11e9-9ba0-4bdc0104adb5.gif)
