### PR TITLE
Quash a false positive warning log message

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -1171,15 +1171,18 @@ enum ZNGConversationSections
     }
     
     ZNGMessage * message = [[[self eventViewModelAtIndexPath:indexPath] event] message];
-    ZNGMessage * priorMessage = [self.conversation priorMessage:message];
     
-    // Have channels changed?
-    ZNGChannel * thisChannel = [[message contactCorrespondent] channel];
-    ZNGChannel * priorChannel = [[priorMessage contactCorrespondent] channel];
-    
-    if ((thisChannel != nil) && (priorChannel != nil) && (![thisChannel isEqual:priorChannel])) {
-        // The channel has changed!
-        return YES;
+    if (message != nil) {
+        ZNGMessage * priorMessage = [self.conversation priorMessage:message];
+        
+        // Have channels changed?
+        ZNGChannel * thisChannel = [[message contactCorrespondent] channel];
+        ZNGChannel * priorChannel = [[priorMessage contactCorrespondent] channel];
+        
+        if ((thisChannel != nil) && (priorChannel != nil) && (![thisChannel isEqual:priorChannel])) {
+            // The channel has changed!
+            return YES;
+        }
     }
     
     return NO;


### PR DESCRIPTION
The conversation UI was a bit too aggressive when trying to detect channel changes and was spewing warnings from every internal note.

![tenor](https://user-images.githubusercontent.com/1328743/65791553-d7596180-e116-11e9-82bd-eb06920cd3e5.gif)
