### PR TITLE
IOS-986: Delay async callback for JWT refresh failure

### DIFF
--- a/Pod/Classes/Clients/ZNGJWTClient.m
+++ b/Pod/Classes/Clients/ZNGJWTClient.m
@@ -91,8 +91,10 @@
             SBLogWarning(@"%@", description);
             
             if (failure != nil) {
-                NSError * error = [NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey: description}];
-                failure(error);
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    NSError * error = [NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey: description}];
+                    failure(error);
+                });
             }
             
             return;


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-986

It's bad form to call an async callback within the same call stack that triggered it.  This was causing timing issues in our (admittedly fragile) iOS app initial launch and login.

![CQlQw](https://user-images.githubusercontent.com/1328743/65796005-79317c00-e120-11e9-88de-bb8cd5d11036.gif)
