### PR TITLE
Updated SDWebImage to 5.0

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -7,7 +7,6 @@ PODS:
   - AFNetworking/Security (3.2.1)
   - AFNetworking/Serialization (3.2.1)
   - Analytics (3.6.10)
-  - FLAnimatedImage (1.0.12)
   - JSQMessagesViewController (7.3.5):
     - JSQMessagesViewController/include-cell-xibs (= 7.3.5)
     - JSQSystemSoundPlayer (~> 2.0.1)
@@ -27,10 +26,9 @@ PODS:
   - MGSwipeTableCell (1.6.8)
   - SBObjectiveCWrapper (1.4.0):
     - SwiftyBeaver (~> 1.4.0)
-  - SDWebImage/Core (4.4.7)
-  - SDWebImage/GIF (4.4.7):
-    - FLAnimatedImage (~> 1.0)
-    - SDWebImage/Core
+  - SDWebImage (5.2.3):
+    - SDWebImage/Core (= 5.2.3)
+  - SDWebImage/Core (5.2.3)
   - Shimmer (1.0.2)
   - Socket.IO-Client-Swift (15.1.0):
     - Starscream (~> 3.1)
@@ -44,7 +42,7 @@ PODS:
     - Mantle
     - MGSwipeTableCell
     - SBObjectiveCWrapper
-    - SDWebImage/GIF
+    - SDWebImage (~> 5.0)
     - Shimmer
     - Socket.IO-Client-Swift
 
@@ -56,7 +54,6 @@ SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - AFNetworking
     - Analytics
-    - FLAnimatedImage
     - JSQSystemSoundPlayer
     - JVFloatLabeledTextField
     - Mantle
@@ -77,19 +74,18 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AFNetworking: b6f891fdfaed196b46c7a83cf209e09697b94057
   Analytics: 63744ad4afa65c3bcdcdb7a94b62515bde5b3900
-  FLAnimatedImage: 4a0b56255d9b05f18b6dd7ee06871be5d3b89e31
   JSQMessagesViewController: b0b7d079f4e5acc0809ec49ea65fad6c7501235a
   JSQSystemSoundPlayer: c5850e77a4363ffd374cd851154b9af93264ed8d
   JVFloatLabeledTextField: cfc44e3c4d493b2ed92ede8035e8e89c2912ba64
   Mantle: 2fa750afa478cd625a94230fbf1c13462f29395b
   MGSwipeTableCell: dc4eca3212ed38a563b27d6aa7b3c01ce656c1e2
   SBObjectiveCWrapper: 854ea56b37cd0031af2b1d6e12c2f965fc4ff86d
-  SDWebImage: c10d14a8883ebd89664f02a422006f66a85c0c5d
+  SDWebImage: 46a7f73228f84ce80990c786e4372cf4db5875ce
   Shimmer: c5374be1c2b0c9e292fb05b339a513cf291cac86
   Socket.IO-Client-Swift: 7cb44c0ffb86e158cee32d0642d30ec5fdcf8f61
   Starscream: 08172b481e145289c4930cb567230fb55897cfa4
   SwiftyBeaver: 25bd76281f49ca989ec2e3cbde9af89c15bc1432
-  ZingleSDK: 3a6e1be618c5782d900e8e753ba94ea49a82a4e1
+  ZingleSDK: f08f0a4707b45b182c7cffa9de4b9ee4f6deb81d
 
 PODFILE CHECKSUM: 4f990b2fa41c7e8b92d657fa2c61486129ae4a47
 

--- a/Example/ZingleSDK.xcodeproj/project.pbxproj
+++ b/Example/ZingleSDK.xcodeproj/project.pbxproj
@@ -485,7 +485,6 @@
 				"${PODS_ROOT}/Target Support Files/Pods-Tests/Pods-Tests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/AFNetworking/AFNetworking.framework",
 				"${BUILT_PRODUCTS_DIR}/Analytics/Analytics.framework",
-				"${BUILT_PRODUCTS_DIR}/FLAnimatedImage/FLAnimatedImage.framework",
 				"${BUILT_PRODUCTS_DIR}/JSQMessagesViewController/JSQMessagesViewController.framework",
 				"${BUILT_PRODUCTS_DIR}/JSQSystemSoundPlayer/JSQSystemSoundPlayer.framework",
 				"${BUILT_PRODUCTS_DIR}/JVFloatLabeledTextField/JVFloatLabeledTextField.framework",
@@ -503,7 +502,6 @@
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AFNetworking.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Analytics.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FLAnimatedImage.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/JSQMessagesViewController.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/JSQSystemSoundPlayer.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/JVFloatLabeledTextField.framework",
@@ -531,7 +529,6 @@
 				"${PODS_ROOT}/Target Support Files/Pods-ZingleSDK_Example/Pods-ZingleSDK_Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/AFNetworking/AFNetworking.framework",
 				"${BUILT_PRODUCTS_DIR}/Analytics/Analytics.framework",
-				"${BUILT_PRODUCTS_DIR}/FLAnimatedImage/FLAnimatedImage.framework",
 				"${BUILT_PRODUCTS_DIR}/JSQMessagesViewController/JSQMessagesViewController.framework",
 				"${BUILT_PRODUCTS_DIR}/JSQSystemSoundPlayer/JSQSystemSoundPlayer.framework",
 				"${BUILT_PRODUCTS_DIR}/JVFloatLabeledTextField/JVFloatLabeledTextField.framework",
@@ -549,7 +546,6 @@
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AFNetworking.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Analytics.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FLAnimatedImage.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/JSQMessagesViewController.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/JSQSystemSoundPlayer.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/JVFloatLabeledTextField.framework",

--- a/Pod/Classes/UI/Controllers/ZNGImageViewController.h
+++ b/Pod/Classes/UI/Controllers/ZNGImageViewController.h
@@ -8,11 +8,11 @@
 
 #import <UIKit/UIKit.h>
 
-@class FLAnimatedImageView;
+@class SDAnimatedImageView;
 
 @interface ZNGImageViewController : UIViewController
 
-@property (nonatomic, strong) IBOutlet FLAnimatedImageView * imageView;
+@property (nonatomic, strong) IBOutlet SDAnimatedImageView * imageView;
 @property (nonatomic, copy) NSURL * imageURL;
 
 @end

--- a/Pod/Classes/UI/Controllers/ZNGImageViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGImageViewController.m
@@ -8,7 +8,6 @@
 
 #import "ZNGImageViewController.h"
 
-@import FLAnimatedImage;
 @import SDWebImage;
 
 @interface ZNGImageViewController ()

--- a/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.m
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.m
@@ -11,7 +11,6 @@
 
 @import SBObjectiveCWrapper;
 @import SDWebImage;
-@import FLAnimatedImage;
 
 NSString * const ZNGEventViewModelImageSizeChangedNotification = @"ZNGEventViewModelImageSizeChangedNotification";
 
@@ -186,7 +185,7 @@ NSString * const ZNGEventViewModelImageSizeChangedNotification = @"ZNGEventViewM
     CGSize previouslyKnownImageSize = [self mediaViewDisplaySize];
     NSURL * attachmentURL = ([self attachmentIsSupported]) ? [NSURL URLWithString:[self attachmentName]] : nil;
 
-    FLAnimatedImageView * animatedImageView = [[FLAnimatedImageView alloc] init];
+    SDAnimatedImageView * animatedImageView = [[SDAnimatedImageView alloc] init];
     animatedImageView.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.05];
     animatedImageView.tintColor = [self _placeholderTint];
     

--- a/ZingleSDK.podspec
+++ b/ZingleSDK.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
   s.dependency 'JSQMessagesViewController/xibs-without-cells'
   s.dependency 'Analytics', '~> 3.0'
   s.dependency 'MGSwipeTableCell'
-  s.dependency 'SDWebImage/GIF'
+  s.dependency 'SDWebImage', '~> 5.0'
   s.dependency 'Socket.IO-Client-Swift'
   s.dependency 'Shimmer'
 end


### PR DESCRIPTION
Migrated `SDWebImage` code since it now includes out-of-the-box GIF support without requiring `FLAnimatedImageView`

![tenor](https://user-images.githubusercontent.com/1328743/67244594-e62dee00-f40e-11e9-8b72-e6469e472b54.gif)
