### PR TITLE
IOS-990: Fix invisible template/field text in conversations

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -1923,7 +1923,8 @@ enum ZNGConversationSections
     // Note that the font needs to be manually applied via NSAttributedString or else the font of the text field
     //  forever changes.
     UIFont * font = textView.font;
-    NSAttributedString * newAttributedText = [[NSAttributedString alloc] initWithString:text attributes:@{NSFontAttributeName: font}];
+    UIColor * textColor = textView.textColor;
+    NSAttributedString * newAttributedText = [[NSAttributedString alloc] initWithString:text attributes:@{NSFontAttributeName: font, NSForegroundColorAttributeName: textColor}];
     NSMutableAttributedString * attributedText = [textView.attributedText mutableCopy];
     [attributedText appendAttributedString:newAttributedText];
     textView.attributedText = attributedText;


### PR DESCRIPTION
Note: defect, so no need to JIRA

https://zingle.atlassian.net/browse/IOS-1002

Apparently setting `attributedText` blows away color settings along with fonts.  We don't want that.

![IC8w7U9](https://user-images.githubusercontent.com/1328743/68432619-a3d41300-0169-11ea-9b20-12c0a6207277.gif)
