### PR TITLE
Set x-zingle-client-version to be the app bundle ID and not the SDK's

### DIFF
--- a/Pod/Classes/ZingleSession.m
+++ b/Pod/Classes/ZingleSession.m
@@ -393,7 +393,7 @@ void __userNotificationWillPresent(id self, SEL _cmd, id notificationCenter, id 
     session.requestSerializer = [AFJSONRequestSerializer serializer];
     [session.requestSerializer setValue:ZNGAgentValue forHTTPHeaderField:ZNGAgentHeaderField];
     [session.requestSerializer setValue:[[NSBundle mainBundle] bundleIdentifier] forHTTPHeaderField:ZNGClientIDField];
-    NSString * bundleVersion = [[NSBundle bundleForClass:[self class]] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+    NSString * bundleVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
     [session.requestSerializer setValue:bundleVersion forHTTPHeaderField:ZNGClientVersionField];
 
     return session;


### PR DESCRIPTION
This was silly.  The bundle ID was 1.1.0 and hasn't been updated in forever.


![gone](https://user-images.githubusercontent.com/1328743/68445003-7ac57980-018d-11ea-953b-24747a8158f4.jpeg)
