### PR TITLE
IOS-990: Correct search bar tint color in tag select view

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGLabelSelectViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGLabelSelectViewController.m
@@ -44,7 +44,11 @@ static NSString * const LabelCellId = @"labelCell";
     searchController.dimsBackgroundDuringPresentation = NO;
     self.definesPresentationContext = YES;
     
-    searchController.searchBar.tintColor = [UIColor whiteColor];
+    searchController.searchBar.tintColor = [UIColor blackColor];
+    
+    if (@available(iOS 13.0, *)) {
+        searchController.searchBar.tintColor = [UIColor labelColor];
+    }
     
     self.tableView.tableHeaderView = searchController.searchBar;
 }


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-1015

The tint color was white when the search bar had a blue background.  In adding dark mode support, this was changed to a normal white/black background.

![images](https://user-images.githubusercontent.com/1328743/68813548-04ac9100-062b-11ea-818b-e80b6e55591f.jpg)
