### PR TITLE
IOS-1019: Fix vanishing text when inserting images/templates/contact fields

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -1919,12 +1919,11 @@ enum ZNGConversationSections
     
     UITextView * textView = self.inputToolbar.contentView.textView;
     
-    // Use the attributed text to preserve any image attachments
-    // Note that the font needs to be manually applied via NSAttributedString or else the font of the text field
+    // Use the attributed text to preserve any image attachments.
+    // Note that the typing attributes need to be manually applied to this new string or else the styling of the text field
     //  forever changes.
-    UIFont * font = textView.font;
-    UIColor * textColor = textView.textColor;
-    NSAttributedString * newAttributedText = [[NSAttributedString alloc] initWithString:text attributes:@{NSFontAttributeName: font, NSForegroundColorAttributeName: textColor}];
+    NSDictionary<NSAttributedStringKey, id> * typingAttributes = textView.typingAttributes;
+    NSAttributedString * newAttributedText = [[NSAttributedString alloc] initWithString:text attributes:typingAttributes];
     NSMutableAttributedString * attributedText = [textView.attributedText mutableCopy];
     [attributedText appendAttributedString:newAttributedText];
     textView.attributedText = attributedText;


### PR DESCRIPTION
https://zingle.atlassian.net/browse/IOS-1019 (subtask, so no JIRA actions needed)

We were previously saving font/color and manually restoring them when adding text/images to `UITextField`s.  A slightly better solution is to apply the text field's `typingAttributes` to any text/image that is being added to the text field (templates, custom fields, and image attachments).  This prevents iOS from blowing away the text field's styling when adding text/images via code.

This PR makes that change and fixes one place where the manual save/restore had missed this.

![b0f358ee3b3749597faedd7cad7b2c4f61608538](https://user-images.githubusercontent.com/1328743/70092704-b9efba80-15d3-11ea-9b19-57faccfb7e63.gif)
