### PR TITLE
TECH-13691: User data from v2 API instead of socket

### DIFF
--- a/Pod/Classes/Clients/ZNGSocketClient.m
+++ b/Pod/Classes/Clients/ZNGSocketClient.m
@@ -539,9 +539,7 @@
     ZingleAccountSession * accountSession = ([self.session isKindOfClass:[ZingleAccountSession class]]) ? (ZingleAccountSession *)self.session : nil;
     ZNGUser * user = [ZNGUser userFromSocketData:userData];
     
-    // The socket data currently uses sequential IDs instead of our UUIDs.  This means that we cannot check vs. our own ID.
-    // Should we check vs. our email/username?
-    if ((self.ignoreCurrentUserTypingIndicator) && ([user.email isEqualToString:accountSession.userAuthorization.email])) {
+    if ((self.ignoreCurrentUserTypingIndicator) && ([user.userId isEqualToString:accountSession.userAuthorization.userId])) {
         SBLogDebug(@"Received a userIsReplying notification for our current user.  Ignoring.");
         return;
     }

--- a/Pod/Classes/Clients/ZNGUserClient.h
+++ b/Pod/Classes/Clients/ZNGUserClient.h
@@ -11,12 +11,17 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class ZNGUser;
+@class ZNGUserV2;
 
 @interface ZNGUserClient : ZNGBaseClientAccount
 
 - (void) userWithId:(NSString *)userId
             success:(void (^)(ZNGUser* user, ZNGStatus* status))success
             failure:(void (^)(ZNGError* error))failure;
+
+- (void) getAllUsersInServiceId:(NSString *)serviceId
+                        success:(void (^)(NSArray<ZNGUserV2 *> * users))success
+                        failure:(void (^ _Nullable)(ZNGError * error))failure;
 
 #pragma mark - Avatars
 - (void) deleteAvatarForUserWithId:(NSString *)userId

--- a/Pod/Classes/Clients/ZNGUserClient.m
+++ b/Pod/Classes/Clients/ZNGUserClient.m
@@ -35,8 +35,6 @@
     NSString * path = [NSString stringWithFormat:@"services/%@/users", serviceId];
     
     [self.session.v2SessionManager GET:path parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
-        NSLog(@"stuff");
-        
         NSError * serializationError = nil;
         NSArray<ZNGUserV2 *> * users = [MTLJSONAdapter modelsOfClass:[ZNGUserV2 class] fromJSONArray:responseObject error:&serializationError];
         

--- a/Pod/Classes/Clients/ZNGUserClient.m
+++ b/Pod/Classes/Clients/ZNGUserClient.m
@@ -9,7 +9,9 @@
 #import "ZNGUserClient.h"
 #import "NSData+ImageType.h"
 #import "ZingleAccountSession.h"
+#import "ZNGUserV2.h"
 
+@import AFNetworking;
 @import SBObjectiveCWrapper;
 
 @implementation ZNGUserClient
@@ -24,6 +26,39 @@
                 responseClass:[ZNGUser class]
                       success:success
                       failure:failure];
+}
+
+- (void) getAllUsersInServiceId:(NSString *)serviceId
+                        success:(void (^)(NSArray<ZNGUserV2 *> * users))success
+                        failure:(void (^ _Nullable)(ZNGError * error))failure
+{
+    NSString * path = [NSString stringWithFormat:@"services/%@/users", serviceId];
+    
+    [self.session.v2SessionManager GET:path parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
+        NSLog(@"stuff");
+        
+        NSError * serializationError = nil;
+        NSArray<ZNGUserV2 *> * users = [MTLJSONAdapter modelsOfClass:[ZNGUserV2 class] fromJSONArray:responseObject error:&serializationError];
+        
+        if ((users != nil) && (serializationError == nil)) {
+            success(users);
+            return;
+        }
+        
+        if (failure != nil) {
+            ZNGError * error = nil;
+            
+            if (serializationError != nil) {
+                error = [[ZNGError alloc] initWithAPIError:error];
+            }
+            
+            failure(error);
+        }
+    } failure:^(NSURLSessionDataTask * _Nullable task, NSError * _Nonnull error) {
+        if (failure != nil) {
+            failure([[ZNGError alloc] initWithAPIError:error]);
+        }
+    }];
 }
 
 - (void) deleteAvatarForUserWithId:(NSString *)userId

--- a/Pod/Classes/Models/ZNGUser.h
+++ b/Pod/Classes/Models/ZNGUser.h
@@ -17,7 +17,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ZNGUser : MTLModel<MTLJSONSerializing>
 
 @property(nonatomic, strong, nullable) NSString * userId;
-@property(nonatomic, assign) int numericId;
 @property(nonatomic, strong, nullable) NSString* username;
 @property(nonatomic, strong, nullable) NSString* email;
 @property(nonatomic, strong, nullable) NSString* firstName;

--- a/Pod/Classes/Models/ZNGUser.m
+++ b/Pod/Classes/Models/ZNGUser.m
@@ -120,10 +120,6 @@ static NSString * const ZNGUserPrivilegeMonitorTeams = @"monitor_teams";
         user.userId = ([userIdUnknownType isKindOfClass:[NSString class]]) ? userIdUnknownType : [userIdUnknownType stringValue];
     }
     
-    if ([data[@"id"] isKindOfClass:[NSNumber class]]) {
-        user.numericId = [data[@"id"] intValue];
-    }
-    
     if ([data[@"isOnline"] isKindOfClass:[NSNumber class]]) {
         user.isOnline = [data[@"isOnline"] boolValue];
     }

--- a/Pod/Classes/Models/ZNGUserV2.h
+++ b/Pod/Classes/Models/ZNGUserV2.h
@@ -1,0 +1,18 @@
+//
+//  ZNGUserV2.h
+//  ZingleSDK
+//
+//  Created by Jason Neel on 3/20/20.
+//
+//  Subclass of `ZNGUser` to allow serialization from the V2 API
+//
+
+#import <ZingleSDK/ZingleSDK.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ZNGUserV2 : ZNGUser
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Pod/Classes/Models/ZNGUserV2.m
+++ b/Pod/Classes/Models/ZNGUserV2.m
@@ -1,0 +1,25 @@
+//
+//  ZNGUserV2.m
+//  ZingleSDK
+//
+//  Created by Jason Neel on 3/20/20.
+//
+
+#import "ZNGUserV2.h"
+
+@implementation ZNGUserV2
+
++ (NSDictionary*)JSONKeyPathsByPropertyKey
+{
+    return @{
+             @"userId" : @"uuid",
+             @"username" : @"username",
+             @"email" : @"email",
+             @"firstName" : @"firstName",
+             @"lastName" : @"lastName",
+             @"title" : @"title",
+             @"avatarUri" : @"avatarUrl",
+             };
+}
+
+@end

--- a/Pod/Classes/ZingleAccountSession.h
+++ b/Pod/Classes/ZingleAccountSession.h
@@ -116,6 +116,13 @@ extern NSString * const ZingleFeedListShouldBeRefreshedNotification;
 @property (nonatomic, strong, nullable) NSArray<ZNGUser *> * users;
 
 /**
+ *  Online user status, externally set by the socket client.
+ *  Prefer using `usersIncludingSelf:`, `usersOnCommonTeamsIncludingSelf:`, etc. to get this data vs. consulting this property.
+ *  Those methods will include accurate `isOnline` flags for each user.
+*/
+@property (nonatomic, strong) NSSet<NSString *> * onlineUserIds;
+
+/**
  *  The manager of all inbox count data.
  */
 @property (nonatomic, strong, nullable) ZNGInboxStatistician * inboxStatistician;

--- a/Pod/Classes/ZingleAccountSession.h
+++ b/Pod/Classes/ZingleAccountSession.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class ZNGTeamClient;
 @class ZNGAssignmentViewController;
 @class ZNGNotificationSettingsClient;
+@class ZNGUserV2;
 
 /**
  *  Notification name posted with an NSNumber bool as the object when the user switches to or from detailed event viewing
@@ -112,6 +113,7 @@ extern NSString * const ZingleFeedListShouldBeRefreshedNotification;
 
 /**
  *  All users in the current service.  Each ZNGUser object includes online status.
+ *  As of March 2020, this data may be incomplete vs. the old V1 API user data as found in `userAuthorization`.
  */
 @property (nonatomic, strong, nullable) NSArray<ZNGUser *> * users;
 


### PR DESCRIPTION
Relevant parent ticket.  Don't mash any buttons in Jira; Android needs updates as well:
https://zingle.atlassian.net/browse/TECH-13691

In the old world, user data came from socket (gross) and included online status.

In the new world, user data is requested from the V2 API.  Socket delivers IDs of online users asynchronously.

We're now better prepared to inhabit this new world.

![giphy](https://user-images.githubusercontent.com/1328743/77216920-816ce180-6adb-11ea-932a-ec0b54849a7f.gif)

