### PR TITLE
ZIN-306: Toggling to and from note entry

### DIFF
--- a/Pod/Assets/ZNGColors.xcassets/ZNGInternalNoteBackground.colorset/Contents.json
+++ b/Pod/Assets/ZNGColors.xcassets/ZNGInternalNoteBackground.colorset/Contents.json
@@ -1,20 +1,20 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0xEF",
           "alpha" : "1.000",
-          "blue" : "0xA3",
-          "green" : "0xDA"
+          "blue" : "0xD9",
+          "green" : "0xF1",
+          "red" : "0xFD"
         }
-      }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.h
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.h
@@ -52,6 +52,9 @@
 @property (nonatomic, strong, nullable) IBOutlet UIButton * automationCancelButton;
 @property (nonatomic, strong, nullable) IBOutlet UILabel * automationRobot;
 
+// A toolbar that only exists to visually cover the gap between the bottom of JSQMessage's toolbar and the bottom of the safe zone
+@property (nonatomic, strong, nullable) IBOutlet UIToolbar * lowerFacadeToolbar;
+
 - (IBAction)pressedCancelAutomation:(nullable id)sender;
 
 // Defaults to YES

--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -1809,34 +1809,6 @@ enum ZNGConversationSections
     [self presentViewController:alert animated:YES completion:nil];
 }
 
-- (void) inputToolbar:(ZNGServiceConversationInputToolbar *)toolbar didPressAddInternalNoteButton:(id)sender
-{
-    UIAlertController * alert = [UIAlertController alertControllerWithTitle:@"Enter an internal note" message:nil preferredStyle:UIAlertControllerStyleAlert];
-    [alert addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
-        textField.placeholder = @"Internal note";
-    }];
-    UIAlertAction * addNote = [UIAlertAction actionWithTitle:@"Add note" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-        UITextField * noteField = [alert.textFields firstObject];
-        NSString * note = [noteField.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-        
-        if ([note length] == 0) {
-            UIAlertController * noteAlert = [UIAlertController alertControllerWithTitle:@"Notes cannot be empty" message:nil preferredStyle:UIAlertControllerStyleAlert];
-            UIAlertAction * ok = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
-            [noteAlert addAction:ok];
-            [self presentViewController:noteAlert animated:YES completion:nil];
-        } else {
-            [self addInternalNote:note];
-        }
-    }];
-    UIAlertAction * cancel = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil];
-    
-    [alert addAction:addNote];
-    [alert addAction:cancel];
-    
-    [self.inputToolbar.contentView.textView resignFirstResponder];
-    [self presentViewController:alert animated:YES completion:nil];
-}
-
 - (void) inputToolbar:(ZNGServiceConversationInputToolbar *)toolbar didPressTriggerAutomationButton:(id)sender
 {
     CGRect sourceRect = [self.view convertRect:toolbar.contentView.automationButton.frame fromView:toolbar.contentView.templateButton.superview];

--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -377,15 +377,11 @@ enum ZNGConversationSections
             BOOL oldLoadedFlag = ([oldLoadedFlagOrNull isKindOfClass:[NSNumber class]]) ? [oldLoadedFlagOrNull boolValue] : NO;
             BOOL loadedFlag = ([loadedFlagOrNull isKindOfClass:[NSNumber class]]) ? [loadedFlagOrNull boolValue] : NO;
             
+            // Did we just finish our initial loading?
             if ((!oldLoadedFlag) && (loadedFlag)) {
                 // Set toolbar type to reflect the last outbound event type as note vs. message if present
                 ZNGEvent * lastEvent = [(ZNGConversationServiceToContact *)self.conversation mostRecentNoteOrOutboundMessage];
-                
-                if ([lastEvent isNote]) {
-                    self.inputToolbar.toolbarMode = TOOLBAR_MODE_INTERNAL_NOTE;
-                } else {
-                    self.inputToolbar.toolbarMode = TOOLBAR_MODE_MESSAGE;
-                }
+                self.inputToolbar.toolbarMode = ([lastEvent isNote]) ? TOOLBAR_MODE_INTERNAL_NOTE : TOOLBAR_MODE_MESSAGE;
             }
         }
     } else {

--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -51,6 +51,7 @@ static NSString * const KVOUserAssignment = @"conversation.contact.assignedToUse
 static NSString * const KVOChannelPath = @"conversation.channel";
 static NSString * const KVOInputLockedPath = @"conversation.lockedDescription";
 static NSString * const KVOReplyingUsersPath = @"conversation.pendingResponses";
+static NSString * const KVOToolbarModePath = @"inputToolbar.toolbarMode";
 
 static NSString * const TypingIndicatorCellID = @"typingIndicator";
 
@@ -160,6 +161,7 @@ enum ZNGConversationSections
     [self addObserver:self forKeyPath:KVOReplyingUsersPath options:NSKeyValueObservingOptionNew|NSKeyValueObservingOptionOld context:KVOContext];
     [self addObserver:self forKeyPath:KVOTeamAssignment options:NSKeyValueObservingOptionNew context:KVOContext];
     [self addObserver:self forKeyPath:KVOUserAssignment options:NSKeyValueObservingOptionNew|NSKeyValueObservingOptionOld context:KVOContext];
+    [self addObserver:self forKeyPath:KVOToolbarModePath options:0 context:KVOContext];
 }
 
 - (void) dealloc
@@ -173,6 +175,7 @@ enum ZNGConversationSections
     [self removeObserver:self forKeyPath:KVOChannelPath context:KVOContext];
     [self removeObserver:self forKeyPath:KVOContactCustomFieldsPath context:KVOContext];
     [self removeObserver:self forKeyPath:KVOContactChannelsPath context:KVOContext];
+    [self removeObserver:self forKeyPath:KVOToolbarModePath context:KVOContext];
     
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
@@ -361,6 +364,10 @@ enum ZNGConversationSections
             }
             
             [self updateTitle];
+        } else if ([keyPath isEqualToString:KVOToolbarModePath]) {
+            // Match our facade toolbar (covering non safe area below the JSQMessages toolbar) color to the actual toolbar color since
+            //  it may change when toggling between message composition and note composition.
+            self.lowerFacadeToolbar.barTintColor = self.inputToolbar.contentView.backgroundColor;
         }
     } else {
         [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];

--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -1895,10 +1895,14 @@ enum ZNGConversationSections
         weakSelf.inputToolbar.inputEnabled = YES;
         [weakSelf scrollToBottomAnimated:YES];
         [[ZNGAnalytics sharedAnalytics] trackAddedNote:note toConversation:weakSelf.conversation];
+        
+        [weakSelf finishSendingMessageAnimated:YES];
     } failure:^(ZNGError * _Nonnull error) {
         weakSelf.inputToolbar.inputEnabled = YES;
         UIAlertController * alert = [UIAlertController alertControllerWithTitle:@"Failed to add note" message:nil preferredStyle:UIAlertControllerStyleAlert];
-        UIAlertAction * ok = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
+        UIAlertAction * ok = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+            [weakSelf finishSendingMessageAnimated:YES];
+        }];
         [alert addAction:ok];
         [weakSelf presentViewController:alert animated:YES completion:nil];
     }];

--- a/Pod/Classes/UI/ViewModels/Events/ZNGConversation.m
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGConversation.m
@@ -228,10 +228,6 @@ NSString * const kMessageDirectionOutbound = @"outbound";
             [self removeSendingEvents];
         }
         
-        if (!self.loadedInitialData) {
-            self.loadedInitialData = YES;
-        }
-        
         self.totalEventCount = status.totalRecords;
         
         // Since we are fetching our data in descending order (so page 1 has recent data,) we need to reverse for proper chronological order
@@ -244,6 +240,10 @@ NSString * const kMessageDirectionOutbound = @"outbound";
         
         [self mergeNewDataAtTail:sortedEvents];
         self.loading = NO;
+        
+        if (!self.loadedInitialData) {
+            self.loadedInitialData = YES;
+        }
         
         if (success) {
             success(status);

--- a/Pod/Classes/UI/ViewModels/Events/ZNGConversation.m
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGConversation.m
@@ -659,7 +659,7 @@ NSString * const kMessageDirectionOutbound = @"outbound";
 
 - (ZNGMessage *) mostRecentInboundMessage
 {
-    for (ZNGEvent * event in self.events) {
+    for (ZNGEvent * event in [self.events reverseObjectEnumerator]) {
         if (([event isMessage]) && (event.message) != nil && (![event.message isOutbound])) {
             return event.message;
         }
@@ -670,7 +670,7 @@ NSString * const kMessageDirectionOutbound = @"outbound";
 
 - (ZNGMessage *) mostRecentMessage
 {
-    for (ZNGEvent * event in self.events) {
+    for (ZNGEvent * event in [self.events reverseObjectEnumerator]) {
         if ([event isMessage]) {
             return event.message;
         }

--- a/Pod/Classes/UI/ViewModels/Events/ZNGConversationServiceToContact.h
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGConversationServiceToContact.h
@@ -83,6 +83,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (NSArray<ZNGChannel *> *) usedChannels;
 
+/**
+ * The most recent outbound message or internal note in this convesration
+ */
+- (nullable ZNGEvent *) mostRecentNoteOrOutboundMessage;
+
 NS_ASSUME_NONNULL_END
 
 @end

--- a/Pod/Classes/UI/ViewModels/Events/ZNGConversationServiceToContact.m
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGConversationServiceToContact.m
@@ -145,6 +145,17 @@ static NSString * const ChannelsKVOPath = @"contact.channels";
     return [_contact fullNameUsingUnformattedPhoneNumberValue:useUnformattedPhoneValue];
 }
 
+- (nullable ZNGEvent *) mostRecentNoteOrOutboundMessage
+{
+    for (ZNGEvent * event in [self.events reverseObjectEnumerator]) {
+        if (([event.message isOutbound]) || ([event isNote])) {
+            return event;
+        }
+    }
+    
+    return nil;
+}
+
 - (void) notifyConversationDataReceived:(NSNotification *)notification
 {
     if ([self notificationRelevantToThisConversation:notification]) {

--- a/Pod/Classes/UI/Views/ZNGServiceConversationInputToolbar.h
+++ b/Pod/Classes/UI/Views/ZNGServiceConversationInputToolbar.h
@@ -26,7 +26,6 @@ NS_ASSUME_NONNULL_BEGIN
 @optional
 - (NSString *)displayNameForChannel:(ZNGChannel *)channel;
 
-- (void) inputToolbar:(ZNGServiceConversationInputToolbar *)toolbar didPressMessageModeButton:(id)sender;
 - (void) inputToolbar:(ZNGServiceConversationInputToolbar *)toolbar didPressUseTemplateButton:(id)sender;
 - (void) inputToolbar:(ZNGServiceConversationInputToolbar *)toolbar didPressInsertCustomFieldButton:(id)sender;
 - (void) inputToolbar:(ZNGServiceConversationInputToolbar *)toolbar didPressTriggerAutomationButton:(id)sender;
@@ -63,7 +62,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (IBAction)didPressInsertCustomField:(id)sender;
 - (IBAction)didPressTriggerAutomation:(id)sender;
 - (IBAction)didPressAttachImage:(id)sender;
-- (IBAction)didPressAddNote:(id)sender;
 
 - (IBAction)didPressChannelSelectButton:(id)sender;
 

--- a/Pod/Classes/UI/Views/ZNGServiceConversationInputToolbar.m
+++ b/Pod/Classes/UI/Views/ZNGServiceConversationInputToolbar.m
@@ -24,6 +24,9 @@
     
     UIImage * sendButtonEnabled;
     UIImage * sendButtonDisabled;
+    
+    NSAttributedString * lastMessageText;
+    NSAttributedString * lastNoteText;
 }
 
 @dynamic contentView;
@@ -83,14 +86,24 @@
 
 - (void) setToolbarMode:(ZNGServiceConversationInputToolbarMode)toolbarMode
 {
-    _toolbarMode = toolbarMode;
-        
     if (toolbarMode == TOOLBAR_MODE_INTERNAL_NOTE) {
         self.contentView.textView.placeHolder = @"Write an internal note";
         self.contentView.backgroundColor = noteBackgroundColor;
+        
+        if (self.toolbarMode != TOOLBAR_MODE_INTERNAL_NOTE) {
+            // We're going from non-note to note mode.  Preserve note text and restore message text.
+            lastMessageText = self.contentView.textView.attributedText;
+            self.contentView.textView.attributedText = lastNoteText;
+        }
     } else {
         self.contentView.textView.placeHolder = @"Type a reply";
         self.contentView.backgroundColor = normalBackgroundColor;
+        
+        if (self.toolbarMode == TOOLBAR_MODE_INTERNAL_NOTE) {
+            // We're going from note mode to non-note mode.  Preserve message text and restore note text.
+            lastNoteText = self.contentView.textView.attributedText;
+            self.contentView.textView.attributedText = lastMessageText;
+        }
     }
 
     switch (toolbarMode) {
@@ -194,6 +207,8 @@
     [self.contentView.automationButton addTarget:self action:@selector(didPressTriggerAutomation:) forControlEvents:UIControlEventTouchUpInside];
     [self.contentView.imageButton addTarget:self action:@selector(didPressAttachImage:) forControlEvents:UIControlEventTouchUpInside];
     [self.contentView.noteButton addTarget:self action:@selector(didPressAddNote:) forControlEvents:UIControlEventTouchUpInside];
+    
+    _toolbarMode = toolbarMode;
 }
 
 - (void) setCurrentChannel:(ZNGChannel *)currentChannel

--- a/Pod/Classes/UI/Views/ZNGServiceConversationInputToolbar.m
+++ b/Pod/Classes/UI/Views/ZNGServiceConversationInputToolbar.m
@@ -16,9 +16,12 @@
 
 @implementation ZNGServiceConversationInputToolbar
 {
+    UIColor * normalBackgroundColor;
+    UIColor * noteBackgroundColor;
     UIColor * originalTextViewTintColor;
     UIColor * normalButtonColor;
     UIColor * highlightedButtonColor;
+    
     UIImage * sendButtonEnabled;
     UIImage * sendButtonDisabled;
 }
@@ -35,6 +38,8 @@
     highlightedButtonColor = [UIColor colorNamed:@"ZNGLinkText" inBundle:bundle compatibleWithTraitCollection:nil];
     sendButtonEnabled = [UIImage imageNamed:@"sendEnabled" inBundle:bundle compatibleWithTraitCollection:nil];
     sendButtonDisabled = [UIImage imageNamed:@"sendDisabled" inBundle:bundle compatibleWithTraitCollection:nil];
+    normalBackgroundColor = self.contentView.backgroundColor;
+    noteBackgroundColor = [UIColor colorNamed:@"ZNGInternalNoteBackground" inBundle:bundle compatibleWithTraitCollection:nil];
     
     self.preferredDefaultHeight = 121.0;
     self.toolbarMode = TOOLBAR_MODE_MESSAGE;
@@ -48,6 +53,7 @@
 
     self.clipsToBounds = YES;
     
+    self.contentView.textView.backgroundColor = [UIColor clearColor];
     self.contentView.textView.font = [UIFont latoFontOfSize:16.0];
     
     self.contentView.rightBarButtonItemWidth = sendButtonSize.width;
@@ -74,6 +80,14 @@
 - (void) setToolbarMode:(ZNGServiceConversationInputToolbarMode)toolbarMode
 {
     _toolbarMode = toolbarMode;
+        
+    if (toolbarMode == TOOLBAR_MODE_INTERNAL_NOTE) {
+        self.contentView.textView.placeHolder = @"Write an internal note";
+        self.contentView.backgroundColor = noteBackgroundColor;
+    } else {
+        self.contentView.textView.placeHolder = @"Type a reply";
+        self.contentView.backgroundColor = normalBackgroundColor;
+    }
 
     switch (toolbarMode) {
         case TOOLBAR_MODE_MESSAGE:
@@ -232,9 +246,7 @@
 
 - (IBAction)didPressMessageModeButton:(id)sender
 {
-    if ([self.delegate respondsToSelector:@selector(inputToolbar:didPressMessageModeButton:)]) {
-        [self.delegate inputToolbar:self didPressMessageModeButton:sender];
-    }
+    self.toolbarMode = TOOLBAR_MODE_MESSAGE;
 }
 
 - (IBAction)didPressUseTemplate:(id)sender
@@ -267,9 +279,7 @@
 
 - (IBAction)didPressAddNote:(id)sender
 {
-    if ([self.delegate respondsToSelector:@selector(inputToolbar:didPressAddInternalNoteButton:)]) {
-        [self.delegate inputToolbar:self didPressAddInternalNoteButton:sender];
-    }
+    self.toolbarMode = TOOLBAR_MODE_INTERNAL_NOTE;
 }
 
 - (IBAction)didPressChannelSelectButton:(id)sender

--- a/Pod/Classes/UI/Views/ZNGServiceConversationInputToolbar.m
+++ b/Pod/Classes/UI/Views/ZNGServiceConversationInputToolbar.m
@@ -38,8 +38,12 @@
     highlightedButtonColor = [UIColor colorNamed:@"ZNGLinkText" inBundle:bundle compatibleWithTraitCollection:nil];
     sendButtonEnabled = [UIImage imageNamed:@"sendEnabled" inBundle:bundle compatibleWithTraitCollection:nil];
     sendButtonDisabled = [UIImage imageNamed:@"sendDisabled" inBundle:bundle compatibleWithTraitCollection:nil];
-    normalBackgroundColor = self.contentView.backgroundColor;
+    normalBackgroundColor = [UIColor whiteColor];
     noteBackgroundColor = [UIColor colorNamed:@"ZNGInternalNoteBackground" inBundle:bundle compatibleWithTraitCollection:nil];
+    
+    if (@available(iOS 13.0, *)) {
+        normalBackgroundColor = [UIColor systemBackgroundColor];
+    }
     
     self.preferredDefaultHeight = 121.0;
     self.toolbarMode = TOOLBAR_MODE_MESSAGE;

--- a/Pod/Classes/UI/Views/ZNGServiceConversationToolbarContentView.xib
+++ b/Pod/Classes/UI/Views/ZNGServiceConversationToolbarContentView.xib
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -23,7 +24,7 @@
                     <rect key="frame" x="0.0" y="0.0" width="320" height="33"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ppu-y2-IOa">
-                            <rect key="frame" x="12" y="1" width="54" height="29"/>
+                            <rect key="frame" x="12" y="1" width="56" height="29"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="29" id="35x-S5-S0X"/>
                             </constraints>
@@ -36,7 +37,7 @@
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iTt-oP-Tqy" userLabel="Arrow Button">
-                            <rect key="frame" x="82" y="4.5" width="12" height="22"/>
+                            <rect key="frame" x="84" y="4.5" width="12" height="22"/>
                             <color key="tintColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                             <state key="normal" image="chevronUp"/>
                             <connections>
@@ -96,6 +97,7 @@
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yZv-vI-ArA" userLabel="Template Button">
                             <rect key="frame" x="43" y="0.0" width="28" height="28"/>
+                            <color key="tintColor" name="ZNGToolbarButton"/>
                             <state key="normal" image="insertTemplate"/>
                             <connections>
                                 <action selector="didPressUseTemplate:" destination="-2" eventType="touchUpInside" id="BB7-cd-xWS"/>
@@ -103,6 +105,7 @@
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aRe-Pu-AIy">
                             <rect key="frame" x="86" y="0.0" width="28" height="28"/>
+                            <color key="tintColor" name="ZNGToolbarButton"/>
                             <state key="normal" image="insertCustomField"/>
                             <connections>
                                 <action selector="didPressInsertCustomField:" destination="-2" eventType="touchUpInside" id="xvb-X2-QI8"/>
@@ -110,6 +113,7 @@
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0Mh-pU-v2i">
                             <rect key="frame" x="129" y="0.0" width="28" height="28"/>
+                            <color key="tintColor" name="ZNGToolbarButton"/>
                             <state key="normal" image="triggerAutomation"/>
                             <connections>
                                 <action selector="didPressTriggerAutomation:" destination="-2" eventType="touchUpInside" id="NbD-wf-Ekp"/>
@@ -117,6 +121,7 @@
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EBX-4C-zka">
                             <rect key="frame" x="172" y="0.0" width="28" height="28"/>
+                            <color key="tintColor" name="ZNGToolbarButton"/>
                             <state key="normal" image="attachImage"/>
                             <connections>
                                 <action selector="didPressAttachImage:" destination="-2" eventType="touchUpInside" id="HDM-LU-3uL"/>
@@ -124,6 +129,7 @@
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Udp-Uc-I4X">
                             <rect key="frame" x="218.5" y="0.0" width="21" height="28"/>
+                            <color key="tintColor" name="ZNGToolbarButton"/>
                             <state key="normal" image="addNote"/>
                             <connections>
                                 <action selector="didPressAddNote:" destination="-2" eventType="touchUpInside" id="a9F-nl-MhI"/>
@@ -183,5 +189,8 @@
         <image name="insertTemplate" width="28" height="28"/>
         <image name="triggerAutomation" width="28" height="28"/>
         <image name="typeMessage" width="28" height="28"/>
+        <namedColor name="ZNGToolbarButton">
+            <color red="0.71372549019607845" green="0.72156862745098038" blue="0.72941176470588232" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
     </resources>
 </document>

--- a/Pod/Classes/UI/Views/ZNGServiceConversationToolbarContentView.xib
+++ b/Pod/Classes/UI/Views/ZNGServiceConversationToolbarContentView.xib
@@ -24,7 +24,7 @@
                     <rect key="frame" x="0.0" y="0.0" width="320" height="33"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ppu-y2-IOa">
-                            <rect key="frame" x="12" y="1" width="56" height="29"/>
+                            <rect key="frame" x="12" y="1" width="54" height="29"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="29" id="35x-S5-S0X"/>
                             </constraints>
@@ -37,7 +37,7 @@
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iTt-oP-Tqy" userLabel="Arrow Button">
-                            <rect key="frame" x="84" y="4.5" width="12" height="22"/>
+                            <rect key="frame" x="82" y="4.5" width="12" height="22"/>
                             <color key="tintColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                             <state key="normal" image="chevronUp"/>
                             <connections>

--- a/Pod/Classes/UI/ZNGConversation.storyboard
+++ b/Pod/Classes/UI/ZNGConversation.storyboard
@@ -581,6 +581,7 @@
                         <outlet property="automationRobot" destination="Jm4-wX-hgr" id="eqm-Ff-baH"/>
                         <outlet property="collectionView" destination="G72-K8-cSu" id="m0g-gs-Y0W"/>
                         <outlet property="inputToolbar" destination="Uqn-aA-lFp" id="vJK-sj-akg"/>
+                        <outlet property="lowerFacadeToolbar" destination="IrD-za-bqt" id="ep6-zC-m6d"/>
                         <outlet property="moreMessagesContainerView" destination="1S3-q5-gQs" id="kVr-pd-0UU"/>
                         <outlet property="moreMessagesLabel" destination="J1p-JT-Rr6" id="NXi-ic-CMc"/>
                         <outlet property="moreMessagesView" destination="MTx-YX-esM" id="QdK-6v-gWE"/>
@@ -692,10 +693,10 @@
                                 </connections>
                             </textField>
                             <view hidden="YES" clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="raY-Ot-4yE">
-                                <rect key="frame" x="0.0" y="122.5" width="375" height="104"/>
+                                <rect key="frame" x="0.0" y="122.5" width="375" height="88"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SVm-1k-Gft">
-                                        <rect key="frame" x="312" y="6.5" width="51" height="33"/>
+                                        <rect key="frame" x="312" y="-1.5" width="51" height="33"/>
                                         <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="17"/>
                                         <state key="normal" title="Search">
                                             <color key="titleColor" name="ZNGLinkText"/>
@@ -705,10 +706,10 @@
                                         </connections>
                                     </button>
                                     <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="j1t-J3-wcW">
-                                        <rect key="frame" x="327.5" y="13" width="20" height="20"/>
+                                        <rect key="frame" x="327.5" y="5" width="20" height="20"/>
                                     </activityIndicatorView>
                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Room number" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6v7-ZW-0uV" customClass="JVFloatLabeledTextField">
-                                        <rect key="frame" x="16" y="58" width="110" height="46"/>
+                                        <rect key="frame" x="16" y="42" width="110" height="46"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="110" id="OAA-C6-Pj7"/>
                                             <constraint firstAttribute="height" constant="46" id="uhc-Yq-zGp"/>
@@ -725,7 +726,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </textField>
                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="100" horizontalCompressionResistancePriority="100" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="HotSOS issue name" textAlignment="natural" minimumFontSize="17" clearButtonMode="always" translatesAutoresizingMaskIntoConstraints="NO" id="wk5-1s-9rR" customClass="ZNGContactEditFloatLabeledTextField">
-                                        <rect key="frame" x="16" y="0.0" width="284" height="50"/>
+                                        <rect key="frame" x="16" y="0.0" width="284" height="34"/>
                                         <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="search"/>
                                         <userDefinedRuntimeAttributes>


### PR DESCRIPTION
https://jira.medallia.com/browse/ZIN-306

- Moved note composition from an ugly alert view to the same input text field that is used for message composition
- Wired note/message mode buttons into logic to actually toggle
- Added beautiful yellow background for note entry

![catnotes](https://user-images.githubusercontent.com/1328743/83571284-5724a080-a4dc-11ea-9c90-6017d3cc84a8.gif)
