### PR TITLE
ZIN-309: Mention highlighting in notes

### DIFF
--- a/Pod/Assets/ZNGColors.xcassets/ZNGInternalNoteHighlightedBackground.colorset/Contents.json
+++ b/Pod/Assets/ZNGColors.xcassets/ZNGInternalNoteHighlightedBackground.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xAB",
+          "green" : "0xE9",
+          "red" : "0xFB"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Pod/Classes/Models/ZNGEvent.h
+++ b/Pod/Classes/Models/ZNGEvent.h
@@ -28,17 +28,19 @@ extern NSString * const ZNGEventTypeAssignmentChange;
 
 @class ZNGContact;
 @class ZNGEventViewModel;
+@class ZNGEventMetadataEntry;
 
 @interface ZNGEvent : MTLModel<MTLJSONSerializing, JSQMessageData>
 
-@property (nonatomic, strong) NSString* eventId;
-@property (nonatomic, strong, nullable) NSString* contactId;
-@property (nonatomic, strong) NSString* eventType;
-@property (nonatomic, strong, nullable) NSString* body;
-@property (nonatomic, strong) NSDate* createdAt;
-@property (nonatomic, strong, nullable) ZNGUser* triggeredByUser;
-@property (nonatomic, strong, nullable) ZNGAutomation* automation;
-@property (nonatomic, strong, nullable) ZNGMessage* message;
+@property (nonatomic, strong) NSString * eventId;
+@property (nonatomic, strong, nullable) NSString * contactId;
+@property (nonatomic, strong) NSString * eventType;
+@property (nonatomic, strong, nullable) NSString * body;
+@property (nonatomic, strong) NSDate * createdAt;
+@property (nonatomic, strong, nullable) ZNGUser * triggeredByUser;
+@property (nonatomic, strong, nullable) ZNGAutomation * automation;
+@property (nonatomic, strong, nullable) ZNGMessage * message;
+@property (nonatomic, strong, nullable) NSArray<ZNGEventMetadataEntry *> * metadata;
 
 /**
  *  The time this event actually came into existence.  For delayed messages, this will be null until the message is sent.

--- a/Pod/Classes/Models/ZNGEvent.m
+++ b/Pod/Classes/Models/ZNGEvent.m
@@ -10,6 +10,7 @@
 #import "ZNGEventViewModel.h"
 #import "ZNGContact.h"
 #import "ZingleValueTransformers.h"
+#import "ZNGEventMetadataEntry.h"
 
 NSString * const ZNGEventTypeMessage = @"message";
 NSString * const ZNGEventTypeNote = @"note";
@@ -61,6 +62,7 @@ NSString * const ZNGEventTypeAssignmentChange = @"assignment_changed";
              @"triggeredByUser" : @"triggered_by_user",
              @"automation" : @"automation",
              @"message" : @"message",
+             NSStringFromSelector(@selector(metadata)): @"metadata",
              };
 }
 
@@ -139,6 +141,11 @@ NSString * const ZNGEventTypeAssignmentChange = @"assignment_changed";
 + (NSValueTransformer*)messageJSONTransformer
 {
     return [MTLJSONAdapter dictionaryTransformerWithModelClass:[ZNGMessage class]];
+}
+
++ (NSValueTransformer *)metadataJSONTransformer
+{
+    return [MTLJSONAdapter arrayTransformerWithModelClass:[ZNGEventMetadataEntry class]];
 }
 
 - (BOOL) isEqual:(ZNGEvent *)other {

--- a/Pod/Classes/Models/ZNGEventMetadataEntry.h
+++ b/Pod/Classes/Models/ZNGEventMetadataEntry.h
@@ -1,0 +1,32 @@
+//
+//  ZNGEventMetadataEntry.h
+//  ZingleSDK
+//
+//  Created by Jason Neel on 6/2/20.
+//
+
+#import <Mantle/Mantle.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSString * const ZNGEventMetadataEntryMentionTypeUser;
+extern NSString * const ZNGEventMetadataEntryMentionTypeTeam;
+
+@interface ZNGEventMetadataEntry : MTLModel <MTLJSONSerializing>
+
+/**
+ * Metadata type, e.g. "userMention" or "teamMention"
+ */
+@property (nonatomic, strong, nullable) NSString * type;
+
+/**
+ * The UUID of the person/team/etc. referenced in the metadata
+ */
+@property (nonatomic, strong, nullable) NSString * uuid;
+
+@property (nonatomic, strong, nullable) NSNumber * start;
+@property (nonatomic, strong, nullable) NSNumber * end;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Pod/Classes/Models/ZNGEventMetadataEntry.m
+++ b/Pod/Classes/Models/ZNGEventMetadataEntry.m
@@ -1,0 +1,25 @@
+//
+//  ZNGEventMetadataEntry.m
+//  ZingleSDK
+//
+//  Created by Jason Neel on 6/2/20.
+//
+
+#import "ZNGEventMetadataEntry.h"
+
+NSString * const ZNGEventMetadataEntryMentionTypeUser = @"userMention";
+NSString * const ZNGEventMetadataEntryMentionTypeTeam = @"teamMention";
+
+@implementation ZNGEventMetadataEntry
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey
+{
+    return @{
+        NSStringFromSelector(@selector(type)): @"type",
+        NSStringFromSelector(@selector(uuid)): @"uuid",
+        NSStringFromSelector(@selector(start)): @"start",
+        NSStringFromSelector(@selector(end)): @"end",
+    };
+}
+
+@end

--- a/Pod/Classes/UI/Controllers/ZNGConversationViewController.h
+++ b/Pod/Classes/UI/Controllers/ZNGConversationViewController.h
@@ -75,6 +75,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) UIColor * internalNoteColor;
 
 /**
+ * The highlight color for mentions in internal notes
+ */
+@property (nonatomic, strong) UIColor * mentionHighlightColor;
+
+/**
  *  Sets the text color of the incoming message text.
  *  Defaults to Zingle gray text color
  */

--- a/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGConversationViewController.m
@@ -26,6 +26,8 @@
 #import "ZNGConversationCellOutgoing.h"
 #import "ZNGConversationCellIncoming.h"
 #import "ZNGEventViewModel.h"
+#import "ZNGEventMetadataEntry.h"
+#import "ZNGMessageTextView.h"
 
 @import SBObjectiveCWrapper;
 @import Shimmer;
@@ -163,6 +165,7 @@ static void * ZNGConversationKVOContext  =   &ZNGConversationKVOContext;
     _incomingTextColor = [UIColor colorNamed:@"ZNGInboundBubbleText" inBundle:bundle compatibleWithTraitCollection:nil];
     _outgoingTextColor = [UIColor colorNamed:@"ZNGOutboundBubbleText" inBundle:bundle compatibleWithTraitCollection:nil];
     _internalNoteTextColor = [UIColor colorNamed:@"ZNGInternalNoteText" inBundle:bundle compatibleWithTraitCollection:nil];
+    _mentionHighlightColor = [UIColor colorNamed:@"ZNGInternalNoteHighlightedBackground" inBundle:bundle compatibleWithTraitCollection:nil];
     _authorTextColor = [UIColor lightGrayColor];
     _messageFont = [UIFont latoFontOfSize:17.0];
     _textInputFont = [UIFont latoFontOfSize:16.0];
@@ -1487,7 +1490,8 @@ static void * ZNGConversationKVOContext  =   &ZNGConversationKVOContext;
                 textColor = self.incomingTextColor;
             }
             
-            NSMutableAttributedString * text = [[NSMutableAttributedString alloc] initWithString:[event text]];
+            NSMutableAttributedString * text = [[viewModel attributedText] mutableCopy];
+            
             JSQMessagesCollectionViewFlowLayout * layout = (JSQMessagesCollectionViewFlowLayout *)collectionView.collectionViewLayout;
             
             NSMutableDictionary * linkAttributes = [[NSMutableDictionary alloc] init];
@@ -1500,6 +1504,10 @@ static void * ZNGConversationKVOContext  =   &ZNGConversationKVOContext;
             
             if (layout.messageBubbleFont != nil) {
                 [text addAttribute:NSFontAttributeName value:layout.messageBubbleFont range:NSMakeRange(0, [text length])];
+            }
+            
+            if ([cell.textView isKindOfClass:[ZNGMessageTextView class]]) {
+                ((ZNGMessageTextView *)cell.textView).mentionHighlightColor = self.mentionHighlightColor;
             }
             
             cell.textView.linkTextAttributes = linkAttributes;

--- a/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.h
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.h
@@ -27,6 +27,21 @@ typedef enum {
  */
 extern NSString * const ZNGEventViewModelImageSizeChangedNotification;
 
+/**
+ * The attribute applied to `attributedText` that surrounds any mention of a user or team.  Value is the UUID of the referenced entity.
+ */
+extern NSString * const ZNGEventMentionAttribute;
+
+/**
+* The attribute applied to `attributedText` that surrounds any mention user.  Value is the UUID of the referenced user.
+*/
+extern NSString * const ZNGEventUserMentionAttribute;
+
+/**
+* The attribute applied to `attributedText` that surrounds any mention of a team.  Value is the UUID of the referenced team.
+*/
+extern NSString * const ZNGEventTeamMentionAttribute;
+
 @class ZNGEvent;
 
 @interface ZNGEventViewModel : NSObject <JSQMessageData, JSQMessageMediaData>
@@ -37,6 +52,11 @@ extern NSString * const ZNGEventViewModelImageSizeChangedNotification;
 @property (nonatomic, assign) NSUInteger index;
 
 @property (nonatomic, strong) ZNGEvent * event;
+
+/**
+ * The body of the event as an `NSAttributedString`, including attributes for mentions
+ */
+@property (nonatomic, readonly) NSAttributedString * attributedText;
 
 /**
  *  The name/URL string of the attachment represented by this ZNGEventViewModel.  nil if this is a text entry.

--- a/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.h
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.h
@@ -59,6 +59,11 @@ extern NSString * const ZNGEventTeamMentionAttribute;
 @property (nonatomic, readonly) NSAttributedString * attributedText;
 
 /**
+ * The extra padding to put around mentions in the `attributedText`.  Defaults to 3.0.
+ */
+@property (nonatomic, assign) CGFloat extraSpaceAroundMentions;
+
+/**
  *  The name/URL string of the attachment represented by this ZNGEventViewModel.  nil if this is a text entry.
  */
 @property (nonatomic, readonly) NSString * attachmentName;

--- a/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.m
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.m
@@ -28,6 +28,7 @@ NSString * const ZNGEventTeamMentionAttribute = @"ZNGEventTeamMentionAttribute";
     if (self != nil) {
         _event = event;
         _index = index;
+        _extraSpaceAroundMentions = 3.0;
         
         if ([self outgoingImageAttachment] != nil) {
             self.attachmentStatus = ZNGEventViewModelAttachmentStatusAvailable;
@@ -153,6 +154,16 @@ NSString * const ZNGEventTeamMentionAttribute = @"ZNGEventTeamMentionAttribute";
             [text addAttribute:ZNGEventUserMentionAttribute value:uuid range:range];
         } else if ([metadata.type isEqualToString:ZNGEventMetadataEntryMentionTypeTeam]) {
             [text addAttribute:ZNGEventTeamMentionAttribute value:uuid range:range];
+        }
+        
+        if (self.extraSpaceAroundMentions > 0.0) {
+            // Extra space before the mention
+            if (range.location > 1) {
+                [text addAttribute:NSKernAttributeName value:@(self.extraSpaceAroundMentions) range:NSMakeRange(range.location - 1, 1)];
+            }
+            
+            // Extra space after
+            [text addAttribute:NSKernAttributeName value:@(self.extraSpaceAroundMentions) range:NSMakeRange(range.location + range.length - 1, 1)];
         }
     }
 

--- a/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.m
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.m
@@ -158,7 +158,7 @@ NSString * const ZNGEventTeamMentionAttribute = @"ZNGEventTeamMentionAttribute";
         
         if (self.extraSpaceAroundMentions > 0.0) {
             // Extra space before the mention
-            if (range.location > 1) {
+            if (range.location > 0) {
                 [text addAttribute:NSKernAttributeName value:@(self.extraSpaceAroundMentions) range:NSMakeRange(range.location - 1, 1)];
             }
             

--- a/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.m
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.m
@@ -141,7 +141,7 @@ NSString * const ZNGEventTeamMentionAttribute = @"ZNGEventTeamMentionAttribute";
         
         NSRange range = NSMakeRange([metadata.start unsignedIntegerValue], [metadata.end unsignedIntegerValue] - [metadata.start unsignedIntegerValue]);
         
-        if ((range.location >= [text length]) || ((range.location + range.length) >= [text length])) {
+        if ((range.location >= [text length]) || ((range.location + range.length) > [text length])) {
             SBLogError(@"Metadata entry range is out of bounds of the event text: %@", metadata);
             continue;
         }

--- a/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.m
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGEventViewModel.m
@@ -161,9 +161,11 @@ NSString * const ZNGEventTeamMentionAttribute = @"ZNGEventTeamMentionAttribute";
             if (range.location > 0) {
                 [text addAttribute:NSKernAttributeName value:@(self.extraSpaceAroundMentions) range:NSMakeRange(range.location - 1, 1)];
             }
-            
+
             // Extra space after
-            [text addAttribute:NSKernAttributeName value:@(self.extraSpaceAroundMentions) range:NSMakeRange(range.location + range.length - 1, 1)];
+            if ((range.location + range.length) < [text length]) {
+                [text addAttribute:NSKernAttributeName value:@(self.extraSpaceAroundMentions) range:NSMakeRange(range.location + range.length - 1, 1)];
+            }
         }
     }
 

--- a/Pod/Classes/UI/Views/ZNGConversationCellOutgoing.xib
+++ b/Pod/Classes/UI/Views/ZNGConversationCellOutgoing.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -56,7 +56,7 @@
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="2qm-c6-OZf" userLabel="Bubble Image View">
                                 <rect key="frame" x="0.0" y="0.0" width="244" height="94"/>
                             </imageView>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vLY-aM-0Dr" customClass="JSQMessagesCellTextView">
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vLY-aM-0Dr" customClass="ZNGMessageTextView">
                                 <rect key="frame" x="0.0" y="0.0" width="244" height="94"/>
                                 <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>

--- a/Pod/Classes/UI/Views/ZNGMessageTextView.h
+++ b/Pod/Classes/UI/Views/ZNGMessageTextView.h
@@ -1,0 +1,31 @@
+//
+//  ZNGMessageTextView.h
+//  ZingleSDK
+//
+//  Created by Jason Neel on 6/3/20.
+//
+
+#import <JSQMessagesViewController/JSQMessagesViewController.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ZNGMessageTextView : JSQMessagesCellTextView
+
+/**
+ * The highlight color to be applied under text with a mentions attribute.  Defaults to a light yellow.
+ */
+@property (nonatomic, strong, nullable) UIColor * mentionHighlightColor;
+
+/**
+ The corner radius of mention highlights.  Defaults to 3.0.
+ */
+@property (nonatomic, assign) CGFloat mentionHighlightCornerRadius;
+
+/**
+ * Extra space to highlight below and to the left of highlighted mentions.  Defaults to 3.0.
+ */
+@property (nonatomic, assign) CGFloat highlightPadding;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Pod/Classes/UI/Views/ZNGMessageTextView.m
+++ b/Pod/Classes/UI/Views/ZNGMessageTextView.m
@@ -139,8 +139,8 @@
     NSMutableArray<NSValue *> * componentRects = [[NSMutableArray alloc] initWithCapacity:[components count]];
     NSUInteger currentLocation = 0;
     
-    // Loop through each word of the string within our range, joining any rects that contain 2+ words on the same line
-    //  into single rects.
+    // Loop through each word of the string within our range, calculating the individual rects surrounding each word
+    //  to be later joined.
     for (NSString * component in components) {
         NSRange searchRange = NSMakeRange(currentLocation, [substring length] - currentLocation);
         NSRange localRange = [substring rangeOfString:component options:0 range:searchRange];

--- a/Pod/Classes/UI/Views/ZNGMessageTextView.m
+++ b/Pod/Classes/UI/Views/ZNGMessageTextView.m
@@ -100,19 +100,25 @@
         
         NSArray<NSValue *> * rects = [self rectsForTextInRange:range];
         
-        for (NSValue * rectValue in rects) {
+        [rects enumerateObjectsUsingBlock:^(NSValue * _Nonnull rectValue, NSUInteger i, BOOL * _Nonnull stop) {
             CGRect rect = [rectValue CGRectValue];
             
             // Pad a bit to the left
             rect.origin.x -= self.highlightPadding;
             rect.size.width += self.highlightPadding;
             
+            // A bit of right padding is also needed if this is a non-terminal part of a split mention
+            if (([rects count] > 1) && (i < ([rects count] - 1))) {
+                rect.size.width += self.highlightPadding;
+            }
+            
             UIView * mentionHighlight = [[UIView alloc] initWithFrame:rect];
             mentionHighlight.backgroundColor = self.mentionHighlightColor;
             mentionHighlight.layer.cornerRadius = self.mentionHighlightCornerRadius;
             [newMentionHighlights addObject:mentionHighlight];
             [self insertSubview:mentionHighlight atIndex:0];
-        }
+        }];
+
     }];
 
     mentionHighlights = newMentionHighlights;

--- a/Pod/Classes/UI/Views/ZNGMessageTextView.m
+++ b/Pod/Classes/UI/Views/ZNGMessageTextView.m
@@ -161,7 +161,8 @@
         
         CGRect rect = [self firstRectForRange:textRange];
         [wordRects addObject:[NSValue valueWithCGRect:rect]];
-        currentLocation += wordRange.length;
+        
+        currentLocation = wordRange.location + wordRange.length;
     }
     
     // We have individual rects for each word in the mention.

--- a/Pod/Classes/UI/Views/ZNGMessageTextView.m
+++ b/Pod/Classes/UI/Views/ZNGMessageTextView.m
@@ -107,8 +107,15 @@
             rect.origin.x -= self.highlightPadding;
             rect.size.width += self.highlightPadding;
             
-            // A bit of right padding is also needed if this is a non-terminal part of a split mention
-            if (([rects count] > 1) && (i < ([rects count] - 1))) {
+            // A bit of right padding is also needed if...
+            //  1) This is a non-terminal part of a split mention
+            BOOL nonTerminalWrapped = (([rects count] > 1) && (i < ([rects count] - 1)));
+            //  2) This is the very last word of the entire message
+            BOOL wordEndsMention = (i == ([rects count] - 1));
+            BOOL mentionEndsMessage = ((range.location + range.length) == [self.attributedText length]);
+            BOOL wordEndsMessage = (wordEndsMention && mentionEndsMessage);
+                                        
+            if (nonTerminalWrapped || wordEndsMessage) {
                 rect.size.width += self.highlightPadding;
             }
             

--- a/Pod/Classes/UI/Views/ZNGMessageTextView.m
+++ b/Pod/Classes/UI/Views/ZNGMessageTextView.m
@@ -1,0 +1,117 @@
+//
+//  ZNGMessageTextView.m
+//  ZingleSDK
+//
+//  Created by Jason Neel on 6/3/20.
+//
+
+#import "ZNGMessageTextView.h"
+#import "ZNGEventViewModel.h"
+
+@implementation ZNGMessageTextView
+{
+    NSArray<UIView *> * mentionHighlights;
+}
+
+- (id) initWithCoder:(NSCoder *)coder
+{
+    self = [super initWithCoder:coder];
+    
+    if (self != nil) {
+        [self commonInit];
+    }
+    
+    return self;
+}
+
+- (id) initWithFrame:(CGRect)frame textContainer:(NSTextContainer *)textContainer
+{
+    self = [super initWithFrame:frame textContainer:textContainer];
+    
+    if (self != nil) {
+        [self commonInit];
+    }
+    
+    return self;
+}
+
+- (void) commonInit
+{
+    NSBundle * bundle = [NSBundle bundleForClass:[ZNGMessageTextView class]];
+    _mentionHighlightColor = [UIColor colorNamed:@"ZNGInternalNoteHighlightedBackground" inBundle:bundle compatibleWithTraitCollection:nil];
+    _mentionHighlightCornerRadius = 3.0;
+    _highlightPadding = 3.0;
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(notifyTextChanged:) name:UITextViewTextDidChangeNotification object:nil];
+}
+
+- (void) dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void) setMentionHighlightColor:(UIColor *)mentionHighlightColor
+{
+    _mentionHighlightColor = mentionHighlightColor;
+    [self updateHighlights];
+}
+
+- (void) setMentionHighlightCornerRadius:(CGFloat)mentionHighlightCornerRadius
+{
+    _mentionHighlightCornerRadius = mentionHighlightCornerRadius;
+    [self updateHighlights];
+}
+
+- (void) setHighlightPadding:(CGFloat)highlightPadding
+{
+    _highlightPadding = highlightPadding;
+    [self updateHighlights];
+}
+
+- (void) layoutSubviews
+{
+    [super layoutSubviews];
+    [self updateHighlights];
+}
+
+- (void) notifyTextChanged:(NSNotification *)notification
+{
+    [self updateHighlights];
+}
+
+- (void) updateHighlights
+{
+    for (UIView * mentionView in mentionHighlights) {
+        [mentionView removeFromSuperview];
+    }
+    
+    __block NSMutableArray<UIView *> * newMentionHighlights = [[NSMutableArray alloc] init];
+    
+    [self.attributedText enumerateAttributesInRange:NSMakeRange(0, [self.attributedText length]) options:0 usingBlock:^(NSDictionary<NSAttributedStringKey,id> * _Nonnull attrs, NSRange range, BOOL * _Nonnull stop) {
+        if (![[attrs allKeys] containsObject:ZNGEventMentionAttribute]) {
+            return;
+        }
+        
+        // Let's go on a thrilling adventure through over-engineered text processing land to find the coordinates for our mention
+        UITextPosition * beginning = self.beginningOfDocument;
+        UITextPosition * start = [self positionFromPosition:beginning offset:range.location];
+        UITextPosition * end = [self positionFromPosition:start offset:range.length];
+        UITextRange * textRange = [self textRangeFromPosition:start toPosition:end];
+        CGRect rect = [self firstRectForRange:textRange];
+        
+        // Pad a bit to the left
+        rect.origin.x -= self.highlightPadding;
+        rect.size.width += self.highlightPadding;
+        
+        UIView * mentionHighlight = [[UIView alloc] initWithFrame:rect];
+        mentionHighlight.backgroundColor = self.mentionHighlightColor;
+        mentionHighlight.layer.cornerRadius = self.mentionHighlightCornerRadius;
+        [newMentionHighlights addObject:mentionHighlight];
+        [self insertSubview:mentionHighlight atIndex:0];
+    }];
+
+    mentionHighlights = newMentionHighlights;
+}
+
+
+@end


### PR DESCRIPTION
https://jira.medallia.com/browse/ZIN-309

- Added support for upcoming `metadata` array of mentions in events returned from the API
- Added `attributedText` getter to `ZNGEventViewModel` to provide attributed text with attributes around mentions of both users and teams, also providing some extra spacing around mentions via kern attributes
- Created subclass of `UITextField` to draw rounded highlights around mentions

![bbbus](https://user-images.githubusercontent.com/1328743/83717823-84f70b80-a5e8-11ea-8abd-2c3e1c803fda.gif)