### PR TITLE
ZIN-308: Mention highlighting/deletion in input

### DIFF
--- a/Pod/Classes/UI/Categories/UITextView+TextRects.h
+++ b/Pod/Classes/UI/Categories/UITextView+TextRects.h
@@ -14,6 +14,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * One of more `CGRect ``NSValue`s that visually contain the specified range.  There will be more than one if this text is wrapped.
 */
+- (NSArray<NSValue *> *) rectsForTextInRange:(NSRange)textRange withExtraPadding:(CGFloat)padding;
+
+/**
+* One of more `CGRect ``NSValue`s that visually contain the specified range.  There will be more than one if this text is wrapped.
+ * This uses the default padding of 3.0.  Use `rectsForTextInRange:withExtraPadding:` to specify different or no padding.
+*/
 - (NSArray<NSValue *> *) rectsForTextInRange:(NSRange)textRange;
 
 @end

--- a/Pod/Classes/UI/Categories/UITextView+TextRects.h
+++ b/Pod/Classes/UI/Categories/UITextView+TextRects.h
@@ -1,0 +1,21 @@
+//
+//  UITextView+TextRects.h
+//  ZingleSDK
+//
+//  Created by Jason Neel on 6/11/20.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UITextView (TextRects)
+
+/**
+* One of more `CGRect ``NSValue`s that visually contain the specified range.  There will be more than one if this text is wrapped.
+*/
+- (NSArray<NSValue *> *) rectsForTextInRange:(NSRange)textRange;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Pod/Classes/UI/Categories/UITextView+TextRects.m
+++ b/Pod/Classes/UI/Categories/UITextView+TextRects.m
@@ -1,0 +1,81 @@
+//
+//  UITextView+TextRects.m
+//  ZingleSDK
+//
+//  Created by Jason Neel on 6/11/20.
+//
+
+#import "UITextView+TextRects.h"
+
+@import SBObjectiveCWrapper;
+
+@implementation UITextView (TextRects)
+
+- (NSArray<NSValue *> *) rectsForTextInRange:(NSRange)textRange;
+{
+    UITextPosition * beginningOfMention = [self positionFromPosition:self.beginningOfDocument offset:textRange.location];
+    
+    // The string defined by our provided range
+    NSString * mentionText = [[self.attributedText attributedSubstringFromRange:textRange] string];
+    
+    // The string split by whitespace into its non-whitespace components (read: words)
+    NSArray<NSString *> * words = [mentionText componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    
+    // This array will include one rect for each word in this mention
+    NSMutableArray<NSValue *> * wordRects = [[NSMutableArray alloc] initWithCapacity:[words count]];
+    NSUInteger currentLocation = 0;
+    
+    // Loop through each word of the string within our range, calculating the individual rects surrounding each word
+    //  to be later joined.
+    for (NSString * word in words) {
+        // The remaining range of mentionText, shrinking forward as we calculate rects for words
+        NSRange searchRange = NSMakeRange(currentLocation, [mentionText length] - currentLocation);
+        
+        // The range of this word within our mentionText
+        NSRange wordRange = [mentionText rangeOfString:word options:0 range:searchRange];
+        
+        if (wordRange.location == NSNotFound) {
+            SBLogError(@"Something has gone horribly wrong when calculating mention string ranges.");
+            return @[];
+        }
+
+        UITextPosition * wordStart = [self positionFromPosition:beginningOfMention offset:wordRange.location];
+        UITextPosition * wordEnd = [self positionFromPosition:wordStart offset:wordRange.length];
+        UITextRange * textRange = [self textRangeFromPosition:wordStart toPosition:wordEnd];
+        
+        CGRect rect = [self firstRectForRange:textRange];
+        [wordRects addObject:[NSValue valueWithCGRect:rect]];
+        
+        currentLocation = wordRange.location + wordRange.length;
+    }
+    
+    // We have individual rects for each word in the mention.
+    // We now need to detect multiple rects that occur on the same line and combine those.
+    NSMutableArray<NSValue *> * joinedRects = [[NSMutableArray alloc] initWithCapacity:[words count]];
+    
+    for (NSValue * rectValue in wordRects) {
+        CGRect thisRect = [rectValue CGRectValue];
+        NSValue * previousRect = [joinedRects lastObject];
+        
+        if ((previousRect != nil) && ([self rectsCoexistOnSingleLine:thisRect secondRect:[previousRect CGRectValue]])) {
+            // Join the two rects
+            [joinedRects removeLastObject];
+            [joinedRects addObject:[NSValue valueWithCGRect:CGRectUnion([previousRect CGRectValue], thisRect)]];
+        } else {
+            [joinedRects addObject:[NSValue valueWithCGRect:thisRect]];
+        }
+    }
+
+    return joinedRects;
+}
+
+- (BOOL) rectsCoexistOnSingleLine:(CGRect)rect1 secondRect:(CGRect)rect2
+{
+    // A strict equivalency check of Y is probably good enough, but we'll be safe and
+    //  add some wiggle room equal to half rect1's height
+    CGFloat margin = rect1.size.height / 2.0;
+    CGFloat diff = fabs(rect1.origin.y - rect2.origin.y);
+    return (diff < margin);
+}
+
+@end

--- a/Pod/Classes/UI/Controllers/ZNGMentionSelectionController.m
+++ b/Pod/Classes/UI/Controllers/ZNGMentionSelectionController.m
@@ -76,6 +76,7 @@ enum {
     
     if (([filteredUsers count] > 0) || ([filteredTeams count] > 0)) {
         [self.tableView reloadData];
+        [self.tableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] atScrollPosition:UITableViewScrollPositionTop animated:NO];
         self.tableView.hidden = NO;
     } else {
         self.tableView.hidden = YES;

--- a/Pod/Classes/UI/Controllers/ZNGMentionSelectionController.m
+++ b/Pod/Classes/UI/Controllers/ZNGMentionSelectionController.m
@@ -76,11 +76,32 @@ enum {
     
     if (([filteredUsers count] > 0) || ([filteredTeams count] > 0)) {
         [self.tableView reloadData];
-        [self.tableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] atScrollPosition:UITableViewScrollPositionTop animated:NO];
+        [self.tableView scrollToRowAtIndexPath:[self topmostIndexPath] atScrollPosition:UITableViewScrollPositionTop animated:NO];
         self.tableView.hidden = NO;
     } else {
         self.tableView.hidden = YES;
     }
+}
+
+- (NSIndexPath *) topmostIndexPath
+{
+    __block NSIndexPath * topmostPath = nil;
+    
+    [mentionSections enumerateObjectsUsingBlock:^(NSNumber * _Nonnull sectionNumber, NSUInteger i, BOOL * _Nonnull stop) {
+        if ([sectionNumber unsignedIntegerValue] == ZNGMentionSectionTeams) {
+            if ([filteredTeams count] > 0) {
+                topmostPath = [NSIndexPath indexPathForRow:0 inSection:i];
+                *stop = YES;
+            }
+        } else if ([sectionNumber unsignedIntegerValue] == ZNGMentionSectionUsers) {
+            if ([filteredUsers count] > 0) {
+                topmostPath = [NSIndexPath indexPathForRow:0 inSection:i];
+                *stop = YES;
+            }
+        }
+    }];
+    
+    return topmostPath;
 }
 
 - (void) updateFilteredUsersAndTeams

--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -227,6 +227,7 @@ enum ZNGConversationSections
     
     [self setupBannerContainer];
     
+    self.inputToolbar.contentView.textView.attributeNamesToHighlight = @[ZNGEventMentionAttribute];
     self.inputToolbar.contentView.textView.placeHolder = @"Type a reply";
     [self.inputToolbar setCurrentChannel:self.conversation.channel];
     

--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -1814,10 +1814,40 @@ enum ZNGConversationSections
         } else if (startingNewMention) {
             mentionInProgressRange = NSMakeRange(range.location, [text length]);
             [self setMentionTypeAheadText:text];
+        } else if (isDeletion) {
+            // We will handle the deletion ourselves in case an entire mention needs to be deleted in one go
+            [self deleteInputTextInRange:range];
+            [textView.delegate textViewDidChange:textView];
+            return NO;  // We deleted it ourselves
         }
     }
     
     return [super textView:textView shouldChangeTextInRange:range replacementText:text];
+}
+
+- (void) deleteInputTextInRange:(NSRange)specifiedDeletionRange
+{
+    if ((specifiedDeletionRange.location == NSNotFound) || (specifiedDeletionRange.length == 0)) {
+        return;
+    }
+    
+    UITextView * textView = self.inputToolbar.contentView.textView;
+    __block NSRange totalDeletionRange = specifiedDeletionRange;
+    
+    // If the deletion range includes part of a mention(s), expand `totalDeletionRange` to include the entire mention(s)
+    [textView.attributedText enumerateAttribute:ZNGEventMentionAttribute inRange:specifiedDeletionRange options:0 usingBlock:^(id  _Nullable value, NSRange attributeRange, BOOL * _Nonnull stop) {
+        if (value != nil) {
+            NSRange effectiveRange;
+            [textView.attributedText attribute:ZNGEventMentionAttribute atIndex:attributeRange.location effectiveRange:&effectiveRange];
+            totalDeletionRange = NSUnionRange(totalDeletionRange, effectiveRange);
+        }
+    }];
+    
+    NSMutableAttributedString * mutableText = [textView.attributedText mutableCopy];
+    [mutableText deleteCharactersInRange:totalDeletionRange];
+    UIFont * font = textView.font;
+    textView.attributedText = mutableText;
+    textView.font = font;
 }
 
 - (void) _textChanged

--- a/Pod/Classes/UI/Views/ZNGConversationTextView.h
+++ b/Pod/Classes/UI/Views/ZNGConversationTextView.h
@@ -12,4 +12,19 @@
 
 @property (nonatomic, assign) BOOL hideCursor;
 
+/**
+ * The background color to apply to highlights for text with the attributes specified in `attributeNamesToHighlight`.  Defaults to a light yellow.
+ */
+@property (nonatomic, strong, nullable) UIColor * attributeHighlightColor;
+
+/**
+ * The corner radius to apply to highlights due to `attributeNamesToHighlight`.  Defaults to 3.0.
+ */
+@property (nonatomic, assign) CGFloat attributeHighlightCornerRadius;
+
+/**
+ * Text attributes that should have highlights of `attributeHighlightColor` applied (for any value of the specified attributes)
+ */
+@property (nonatomic, strong, nullable) NSArray<NSString *> * attributeNamesToHighlight;
+
 @end

--- a/Pod/Classes/UI/Views/ZNGConversationTextView.m
+++ b/Pod/Classes/UI/Views/ZNGConversationTextView.m
@@ -49,6 +49,18 @@
     NSBundle * bundle = [NSBundle bundleForClass:[ZNGConversationTextView class]];
     self.attributeHighlightColor = [UIColor colorNamed:@"ZNGInternalNoteHighlightedBackground" inBundle:bundle compatibleWithTraitCollection:nil];
     self.attributeHighlightCornerRadius = 3.0;
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(notifyTextChanged:) name:UITextViewTextDidChangeNotification object:self];
+}
+
+- (void) dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void) notifyTextChanged:(NSNotification *)notification
+{
+    [self updateHighlights];
 }
 
 - (void) setAttributedText:(NSAttributedString *)attributedText

--- a/Pod/Classes/UI/Views/ZNGConversationTextView.m
+++ b/Pod/Classes/UI/Views/ZNGConversationTextView.m
@@ -103,7 +103,16 @@
 - (void) layoutSubviews
 {
     [super layoutSubviews];
-    [self updateHighlights];
+    
+    // We need to update our highlights when laying out subviews, but NSTextStorage gets quite upset if we attempt to calculate coordinates
+    //  while it has an edit in progress.  We will defer to the next run loop iteration if an edit is in progress.
+    if (self.textStorage.editedRange.location == NSNotFound) {
+        [self updateHighlights];
+    } else {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self updateHighlights];
+        });
+    }
 }
 
 - (void) updateHighlights

--- a/Pod/Classes/UI/Views/ZNGMessageTextView.m
+++ b/Pod/Classes/UI/Views/ZNGMessageTextView.m
@@ -7,6 +7,7 @@
 
 #import "ZNGMessageTextView.h"
 #import "ZNGEventViewModel.h"
+#import "UITextView+TextRects.h"
 
 @import SBObjectiveCWrapper;
 
@@ -129,76 +130,6 @@
     }];
 
     mentionHighlights = newMentionHighlights;
-}
-
-/**
- * One of more CGRects that visually contain the specified range.  There will be more than one if this text is wrapped.
- */
-- (NSArray<NSValue *> *) rectsForTextInRange:(NSRange)mentionRange
-{
-    UITextPosition * beginningOfMention = [self positionFromPosition:self.beginningOfDocument offset:mentionRange.location];
-    
-    // The string defined by our provided range
-    NSString * mentionText = [[self.attributedText attributedSubstringFromRange:mentionRange] string];
-    
-    // The string split by whitespace into its non-whitespace components (read: words)
-    NSArray<NSString *> * words = [mentionText componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-    
-    // This array will include one rect for each word in this mention
-    NSMutableArray<NSValue *> * wordRects = [[NSMutableArray alloc] initWithCapacity:[words count]];
-    NSUInteger currentLocation = 0;
-    
-    // Loop through each word of the string within our range, calculating the individual rects surrounding each word
-    //  to be later joined.
-    for (NSString * word in words) {
-        // The remaining range of mentionText, shrinking forward as we calculate rects for words
-        NSRange searchRange = NSMakeRange(currentLocation, [mentionText length] - currentLocation);
-        
-        // The range of this word within our mentionText
-        NSRange wordRange = [mentionText rangeOfString:word options:0 range:searchRange];
-        
-        if (wordRange.location == NSNotFound) {
-            SBLogError(@"Something has gone horribly wrong when calculating mention string ranges.");
-            return @[];
-        }
-
-        UITextPosition * wordStart = [self positionFromPosition:beginningOfMention offset:wordRange.location];
-        UITextPosition * wordEnd = [self positionFromPosition:wordStart offset:wordRange.length];
-        UITextRange * textRange = [self textRangeFromPosition:wordStart toPosition:wordEnd];
-        
-        CGRect rect = [self firstRectForRange:textRange];
-        [wordRects addObject:[NSValue valueWithCGRect:rect]];
-        
-        currentLocation = wordRange.location + wordRange.length;
-    }
-    
-    // We have individual rects for each word in the mention.
-    // We now need to detect multiple rects that occur on the same line and combine those.
-    NSMutableArray<NSValue *> * joinedRects = [[NSMutableArray alloc] initWithCapacity:[words count]];
-    
-    for (NSValue * rectValue in wordRects) {
-        CGRect thisRect = [rectValue CGRectValue];
-        NSValue * previousRect = [joinedRects lastObject];
-        
-        if ((previousRect != nil) && ([self rectsCoexistOnSingleLine:thisRect secondRect:[previousRect CGRectValue]])) {
-            // Join the two rects
-            [joinedRects removeLastObject];
-            [joinedRects addObject:[NSValue valueWithCGRect:CGRectUnion([previousRect CGRectValue], thisRect)]];
-        } else {
-            [joinedRects addObject:[NSValue valueWithCGRect:thisRect]];
-        }
-    }
-
-    return joinedRects;
-}
-
-- (BOOL) rectsCoexistOnSingleLine:(CGRect)rect1 secondRect:(CGRect)rect2
-{
-    // A strict equivalency check of Y is probably good enough, but we'll be safe and
-    //  add some wiggle room equal to half rect1's height
-    CGFloat margin = rect1.size.height / 2.0;
-    CGFloat diff = fabs(rect1.origin.y - rect2.origin.y);
-    return (diff < margin);
 }
 
 @end

--- a/Pod/Classes/UI/Views/ZNGMessageTextView.m
+++ b/Pod/Classes/UI/Views/ZNGMessageTextView.m
@@ -98,35 +98,15 @@
         }
         
         // We have a mention.  Let's calculate the rect(s) that contain it and add highlighter background views.
-        
         NSArray<NSValue *> * rects = [self rectsForTextInRange:range];
         
-        [rects enumerateObjectsUsingBlock:^(NSValue * _Nonnull rectValue, NSUInteger i, BOOL * _Nonnull stop) {
-            CGRect rect = [rectValue CGRectValue];
-            
-            // Pad a bit to the left
-            rect.origin.x -= self.highlightPadding;
-            rect.size.width += self.highlightPadding;
-            
-            // A bit of right padding is also needed if...
-            //  1) This is a non-terminal part of a split mention
-            BOOL nonTerminalWrapped = (([rects count] > 1) && (i < ([rects count] - 1)));
-            //  2) This is the very last word of the entire message
-            BOOL wordEndsMention = (i == ([rects count] - 1));
-            BOOL mentionEndsMessage = ((range.location + range.length) == [self.attributedText length]);
-            BOOL wordEndsMessage = (wordEndsMention && mentionEndsMessage);
-                                        
-            if (nonTerminalWrapped || wordEndsMessage) {
-                rect.size.width += self.highlightPadding;
-            }
-            
-            UIView * mentionHighlight = [[UIView alloc] initWithFrame:rect];
+        for (NSValue * rectValue in rects) {
+            UIView * mentionHighlight = [[UIView alloc] initWithFrame:[rectValue CGRectValue]];
             mentionHighlight.backgroundColor = self.mentionHighlightColor;
             mentionHighlight.layer.cornerRadius = self.mentionHighlightCornerRadius;
             [newMentionHighlights addObject:mentionHighlight];
             [self insertSubview:mentionHighlight atIndex:0];
-        }];
-
+        }
     }];
 
     mentionHighlights = newMentionHighlights;


### PR DESCRIPTION
https://jira.medallia.com/browse/ZIN-308

- Moved the text coordinate code used by mention highlighting logic out of the conversation bubble text view class and into a reusable category on `UITextView`
- Update input to use the above highlighting logic
- Deletion/editing of any part of a completed mention now removes/replaces that entire mention

![chaos](https://user-images.githubusercontent.com/1328743/84697346-d5cd0500-af02-11ea-8269-a696428331ae.gif)
