### PR TITLE
ZIN-1433: Add support for OAuth token exchange

### DIFF
--- a/Pod/Classes/Clients/ZNGJWTClient.h
+++ b/Pod/Classes/Clients/ZNGJWTClient.h
@@ -27,6 +27,11 @@ NS_ASSUME_NONNULL_BEGIN
                    success:(void (^_Nullable)(NSString * jwt))success
                    failure:(void (^_Nullable)(NSError * error))failure;
 
+- (void) acquireJwtFromOauthProvider:(NSString *)oauthProvider
+                               token:(NSString *)token
+                             success:(void (^_Nullable)(NSString * jwt))success
+                             failure:(void (^_Nullable)(NSError * error))failure;
+
 - (void) refreshJwt:(NSString *)jwt
             success:(void (^_Nullable)(NSString * jwt))success
             failure:(void (^_Nullable)(NSError * error))failure;


### PR DESCRIPTION
SDK work for https://jira.medallia.com/browse/ZIN-1433

- Moved some JWT processing code into a common method
- Added support for the new API endpoint that allows exchanging an OAuth token from an arbitrary identity provider for a JWT

![tenor](https://user-images.githubusercontent.com/1328743/93257481-c2c01000-f751-11ea-8fd1-9e256be6b2fd.gif)
