### PR TITLE
Some cleanup for building with the iOS 14 SDK

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGAssignmentViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGAssignmentViewController.m
@@ -198,6 +198,10 @@ enum TopSectionRows {
         UITableViewHeaderFooterView * header = (UITableViewHeaderFooterView *)view;
         header.textLabel.textAlignment = NSTextAlignmentCenter;
         header.textLabel.textColor = [UIColor colorWithWhite:0.75 alpha:1.0];
+        
+        if (@available(iOS 13, *)) {
+            header.textLabel.textColor = [UIColor secondaryLabelColor];
+        }
     }
 }
 

--- a/Pod/Classes/UI/Controllers/ZNGContactEditViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGContactEditViewController.m
@@ -664,7 +664,7 @@ static NSString * const EventCellId = @"event";
             header.sectionImage.image = [UIImage imageNamed:@"editIconLabels" inBundle:bundle compatibleWithTraitCollection:nil];
             break;
         case ContactSectionOptionalCustomFields:
-            header.sectionLabel.text = @"CUSTOM FIELDS";
+            header.sectionLabel.text = @"CONTACT FIELDS";
             header.sectionImage.image = [UIImage imageNamed:@"editIconCustomFields" inBundle:bundle compatibleWithTraitCollection:nil];
             break;
         default:

--- a/Pod/Classes/UI/Controllers/ZNGContactEditViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGContactEditViewController.m
@@ -679,7 +679,10 @@ static NSString * const EventCellId = @"event";
 
 - (UIView *) tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
 {
-    return [tableView dequeueReusableHeaderFooterViewWithIdentifier:FooterReuseIdentifier];
+    UIView * footer = [tableView dequeueReusableHeaderFooterViewWithIdentifier:FooterReuseIdentifier];
+    footer.tintColor = [UIColor clearColor];
+    
+    return footer;
 }
 
 #pragma mark - Table view data source

--- a/Pod/Classes/UI/Views/Contact Editing/ZNGContactCustomFieldTableViewCell.m
+++ b/Pod/Classes/UI/Views/Contact Editing/ZNGContactCustomFieldTableViewCell.m
@@ -153,6 +153,11 @@
         [self setupTimeFormatters];
         self.textField.clearButtonMode = UITextFieldViewModeAlways;
         datePicker = [[UIDatePicker alloc] init];
+        
+        if (@available(iOS 13.4, *)) {
+            datePicker.preferredDatePickerStyle = UIDatePickerStyleWheels;
+        }
+        
         datePicker.datePickerMode = UIDatePickerModeTime;
         datePicker.minuteInterval = 5;
         [datePicker addTarget:self action:@selector(datePickerSelectedTime:) forControlEvents:UIControlEventValueChanged];
@@ -166,6 +171,11 @@
     } else if ([self.customFieldValue.customField.dataType isEqualToString:ZNGContactFieldDataTypeDate]) {
         self.textField.clearButtonMode = UITextFieldViewModeAlways;
         datePicker = [[UIDatePicker alloc] init];
+        
+        if (@available(iOS 13.4, *)) {
+            datePicker.preferredDatePickerStyle = UIDatePickerStyleWheels;
+        }
+        
         datePicker.datePickerMode = UIDatePickerModeDate;
         datePicker.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
         datePicker.timeZone = [NSTimeZone timeZoneWithName:@"UTC"];

--- a/Pod/Classes/UI/Views/ZNGEditContactFooter.xib
+++ b/Pod/Classes/UI/Views/ZNGEditContactFooter.xib
@@ -16,7 +16,6 @@
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ks5-5S-GbB">
                     <rect key="frame" x="0.0" y="0.0" width="472" height="12"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </view>
             </subviews>
             <constraints>
@@ -30,9 +29,4 @@
             <point key="canvasLocation" x="382" y="67"/>
         </view>
     </objects>
-    <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-    </resources>
 </document>

--- a/Pod/Classes/UI/Views/ZNGEditContactFooter.xib
+++ b/Pod/Classes/UI/Views/ZNGEditContactFooter.xib
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12120"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17156"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -17,6 +16,7 @@
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ks5-5S-GbB">
                     <rect key="frame" x="0.0" y="0.0" width="472" height="12"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </view>
             </subviews>
             <constraints>
@@ -30,4 +30,9 @@
             <point key="canvasLocation" x="382" y="67"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Pod/Classes/UI/Views/ZNGEditContactFooter.xib
+++ b/Pod/Classes/UI/Views/ZNGEditContactFooter.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17156"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12120"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>


### PR DESCRIPTION
Handling slight behavior differences in iOS 14:
- Contact edit footer tint color now needs to be specifically set to transparent
- Date pickers must now be manually set to `.wheels` to work as `inputView`s

Small issues totally unrelated to iOS 14 but found at the same time:
- An old contact fields header was still called "custom fields"
- Header background color was wrong in light mode in the assignment view

![1479134845-confused-gif](https://user-images.githubusercontent.com/1328743/93647777-1898f000-f9be-11ea-9ac2-9beeedbc8c29.gif)
