### PR TITLE
ZIN-1174: Add an optional flag on logout to keep push notifications alive

### DIFF
--- a/Pod/Classes/ZingleAccountSession.m
+++ b/Pod/Classes/ZingleAccountSession.m
@@ -141,11 +141,6 @@ NSString * const ZingleFeedListShouldBeRefreshedNotification = @"ZingleFeedListS
     [self retrieveAvailableAccounts];
 }
 
-- (void) logout
-{
-    [self logoutPreservingPushNotifications:NO];
-}
-
 - (void) logoutPreservingPushNotifications:(BOOL)keepPushSubscriptions
 {
     [_conversationCache removeAllObjects];

--- a/Pod/Classes/ZingleAccountSession.m
+++ b/Pod/Classes/ZingleAccountSession.m
@@ -143,9 +143,15 @@ NSString * const ZingleFeedListShouldBeRefreshedNotification = @"ZingleFeedListS
 
 - (void) logout
 {
+    [self logoutPreservingPushNotifications:NO];
+}
+
+- (void) logoutPreservingPushNotifications:(BOOL)keepPushSubscriptions
+{
     [_conversationCache removeAllObjects];
     [self.socketClient disconnect];
-    [super logout];
+    
+    [super logoutPreservingPushNotifications:keepPushSubscriptions];
 }
 
 - (void) cache:(NSCache *)cache willEvictObject:(id)obj

--- a/Pod/Classes/ZingleSession.h
+++ b/Pod/Classes/ZingleSession.h
@@ -116,7 +116,7 @@
 /**
  *  Ends the current session, optionally keeping push notifications working.
  */
-- (void) logoutPreservingPushNotifications:(BOOL)keepPushSubscriptions;
+- (void) logoutPreservingPushNotifications:(BOOL)keepPushSubscriptions NS_REQUIRES_SUPER;
 
 /**
  *  Reset the password associated with the provided email address.

--- a/Pod/Classes/ZingleSession.h
+++ b/Pod/Classes/ZingleSession.h
@@ -114,6 +114,11 @@
 - (void) logout NS_REQUIRES_SUPER;
 
 /**
+ *  Ends the current session, optionally keeping push notifications working.
+ */
+- (void) logoutPreservingPushNotifications:(BOOL)keepPushSubscriptions;
+
+/**
  *  Reset the password associated with the provided email address.
  */
 + (void) resetPasswordForEmail:(nonnull NSString *)email completion:(void (^_Nullable)(BOOL success))completion;

--- a/Pod/Classes/ZingleSession.m
+++ b/Pod/Classes/ZingleSession.m
@@ -234,7 +234,14 @@ void __userNotificationWillPresent(id self, SEL _cmd, id notificationCenter, id 
 
 - (void) logout
 {
-    [self _unregisterForAllPushNotifications];
+    [self logoutPreservingPushNotifications:NO];
+}
+
+- (void) logoutPreservingPushNotifications:(BOOL)keepPushSubscriptions
+{
+    if (!keepPushSubscriptions) {
+        [self _unregisterForAllPushNotifications];
+    }
 }
 
 - (void) setUrlString:(NSString *)urlString


### PR DESCRIPTION
https://jira.medallia.com/browse/ZIN-1174

The old logout also removed push notification subscriptions. Current work on idle logout demands that pushes survive.

![100562](https://user-images.githubusercontent.com/1328743/95125148-5eb5b980-0709-11eb-9f3c-e32e4a4c1e1d.gif)
