### PR TITLE
ZIN-1809: Disallow image attachments for HIPAA users

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -1748,6 +1748,15 @@ enum ZNGConversationSections
 // Our super implementation of this is fine, but we must first ensure that there is a channel selected
 - (void) inputToolbar:(ZNGServiceConversationInputToolbar *)toolbar didPressAttachImageButton:(id)sender
 {
+    // TODO: Replace this ugly HIPAA code (ugly fix ZIN-1809, good fix coming in ZIN-1811)
+    if ([self.conversation.session userHasHipaaAccess]) {
+        UIAlertController * alert = [UIAlertController alertControllerWithTitle:@"Attachments Disabled" message:@"This service does not allow image attachments, per HIPAA guidelines." preferredStyle:UIAlertControllerStyleAlert];
+        UIAlertAction * ok = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
+        [alert addAction:ok];
+        [self presentViewController:alert animated:YES completion:nil];
+        return;
+    }
+    
     if (self.conversation.channel == nil) {
         UIAlertController * alert = [UIAlertController alertControllerWithTitle:@"Please select a channel" message:@"A channel must be selected before sending an image." preferredStyle:UIAlertControllerStyleAlert];
         UIAlertAction * ok = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];


### PR DESCRIPTION
https://jira.medallia.com/browse/ZIN-1809

Show an ugly NO YOU DON'T modal when HIPAA users dare to attach an image.

A less ugly fix will come with the mentions release. (This toolbar code was heavily refactored from its current disaster to a modular set of buttons to support mentions.) Less ugly fix will arrive in https://jira.medallia.com/browse/ZIN-1811

![tenor](https://user-images.githubusercontent.com/1328743/98857801-6ce7ab80-2414-11eb-8e0c-054fe463e5f3.gif)
