### PR TITLE
ZIN-1809: Disable HIPAA attachments by active service not all accessible services

### DIFF
--- a/Pod/Classes/Models/ZNGService/ZNGService.h
+++ b/Pod/Classes/Models/ZNGService/ZNGService.h
@@ -28,6 +28,7 @@
 extern NSString * _Nonnull const ZNGServiceFeatureTeams;
 extern NSString * _Nonnull const ZNGServiceFeatureAssignment;
 extern NSString * _Nonnull const ZNGServiceFeatureCalendarEvents;
+extern NSString * _Nonnull const ZNGServiceFeatureHipaa;
 
 @interface ZNGService : MTLModel<MTLJSONSerializing>
 
@@ -56,6 +57,7 @@ extern NSString * _Nonnull const ZNGServiceFeatureCalendarEvents;
 - (NSArray<ZNGAutomation *> * _Nullable) activeAutomations;
 
 - (BOOL) isTextRelay;
+- (BOOL) isHipaa;
 
 - (ZNGChannelType * _Nullable)phoneNumberChannelType;
 - (ZNGChannelType * _Nullable)channelTypeWithDisplayName:(NSString * _Nonnull)channelDisplayName;

--- a/Pod/Classes/Models/ZNGService/ZNGService.m
+++ b/Pod/Classes/Models/ZNGService/ZNGService.m
@@ -31,6 +31,7 @@
 NSString * const ZNGServiceFeatureTeams = @"teams";
 NSString * const ZNGServiceFeatureAssignment = @"assignment";
 NSString * const ZNGServiceFeatureCalendarEvents = @"calendar_events";
+NSString * const ZNGServiceFeatureHipaa = @"hipaa";
 
 @implementation ZNGService
 
@@ -78,6 +79,11 @@ NSString * const ZNGServiceFeatureCalendarEvents = @"calendar_events";
 - (BOOL) isTextRelay
 {
     return [self.plan isTextRelay];
+}
+
+- (BOOL) isHipaa
+{
+    return [self.features containsObject:ZNGServiceFeatureHipaa];
 }
 
 + (NSValueTransformer*)accountJSONTransformer

--- a/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGServiceToContactViewController.m
@@ -1749,7 +1749,7 @@ enum ZNGConversationSections
 - (void) inputToolbar:(ZNGServiceConversationInputToolbar *)toolbar didPressAttachImageButton:(id)sender
 {
     // TODO: Replace this ugly HIPAA code (ugly fix ZIN-1809, good fix coming in ZIN-1811)
-    if ([self.conversation.session userHasHipaaAccess]) {
+    if ([self.conversation.session.service isHipaa]) {
         UIAlertController * alert = [UIAlertController alertControllerWithTitle:@"Attachments Disabled" message:@"This service does not allow image attachments, per HIPAA guidelines." preferredStyle:UIAlertControllerStyleAlert];
         UIAlertAction * ok = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
         [alert addAction:ok];


### PR DESCRIPTION
https://jira.medallia.com/browse/ZIN-1809

A user who has HIPAA access should still be able to attach images when using non HIPAA services.

![cars-menu-hippo](https://user-images.githubusercontent.com/1328743/98994777-3168e200-24e5-11eb-8afa-ec6e75fb49ca.png)
