### PR TITLE
ZIN-1647: Add ability to sort inbox by arbitrary fields and unconfirmed time

### DIFF
--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.h
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.h
@@ -45,8 +45,9 @@
 @property (nonatomic, assign) BOOL allowContactsWithNoMessages;
 
 /**
- *  The fields used to sort contacts.  May include "asc" or "desc" after a space to define order.
- *  e.g. "last_name asc", "created_at desc"
+ *  The fields (by name for some stock options or UUID for any date/datetime contact field) used to sort contacts.
+ *  May include "asc" or "desc" after a space to define order.
+ *  e.g. "last_name asc", "created_at desc", "264da6d4-f555-4e35-bf86-c42f8dc47357 asc"
  *
  *  Defaults to ["last_message_created_at desc"]
  */

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.h
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.h
@@ -19,6 +19,7 @@ typedef enum {
 
 extern NSString * _Nonnull const ZNGInboxDataSetSortFieldContactCreatedAt;
 extern NSString * _Nonnull const ZNGInboxDataSetSortFieldLastMessageCreatedAt;
+extern NSString * _Nonnull const ZNGInboxDataSetSortFieldUnconfirmedAt;
 extern NSString * _Nonnull const ZNGInboxDataSetSortFieldLastName;
 extern NSString * _Nonnull const ZNGInboxDataSetSortDirectionAscending;
 extern NSString * _Nonnull const ZNGInboxDataSetSortDirectionDescending;

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.h
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.h
@@ -88,8 +88,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) BOOL allowContactsWithNoMessages;
 
 /**
- *  The fields used to sort contacts.  May include "asc" or "desc" after a space to define order.
- *  e.g. "last_name asc", "created_at desc"
+ *  The fields (by name for some stock options or UUID for any date/datetime contact field) used to sort contacts.
+ *  May include "asc" or "desc" after a space to define order.
+ *  e.g. "last_name asc", "created_at desc", "264da6d4-f555-4e35-bf86-c42f8dc47357 asc"
  *
  *  Defaults to ["last_message_created_at desc"]
  */

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGInboxDataSet.m
@@ -37,6 +37,7 @@ static NSString * const ParameterValueGreaterThanZero      = @"greater_than(0)";
 
 NSString * const ZNGInboxDataSetSortFieldContactCreatedAt = @"created_at";
 NSString * const ZNGInboxDataSetSortFieldLastMessageCreatedAt = @"last_message_created_at";
+NSString * const ZNGInboxDataSetSortFieldUnconfirmedAt = @"unconfirmed_at";
 NSString * const ZNGInboxDataSetSortFieldLastName = @"last_name";
 NSString * const ZNGInboxDataSetSortDirectionAscending = @"asc";
 NSString * const ZNGInboxDataSetSortDirectionDescending = @"desc";


### PR DESCRIPTION
https://jira.medallia.com/browse/ZIN-1647

- Adding support for arbitrary fields was as simple as updating the doc comment
- Added `unconfirmed_at` to inbox sorting constants

![il_570xN 2010318605_9k97](https://user-images.githubusercontent.com/1328743/101072317-ae223580-3552-11eb-9b3d-853170ad3091.jpg)
