### PR TITLE
ZIN-1648: Add check for needed contact fields to existing inbox data filter availability check

### DIFF
--- a/Pod/Classes/Logging/ZNGAnalytics.m
+++ b/Pod/Classes/Logging/ZNGAnalytics.m
@@ -180,6 +180,7 @@ static NSString * const HostPropertyName = @"Host";
     NSString * event = @"Inbox filter changed";
     NSMutableDictionary * properties = [self defaultProperties];
     properties[@"inboxType"] = [inboxData description];
+    properties[@"sorting"] = [inboxData sortFields];
     
     [self _track:event properties:properties];
 }

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.m
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.m
@@ -137,17 +137,19 @@
             
             if (uuidRange.location != NSNotFound) {
                 NSString * fieldUuid = [sortField substringWithRange:uuidRange];
+                BOOL foundThisField = NO;
                 
                 for (ZNGContactField * field in session.service.contactCustomFields) {
                     if ([field.contactFieldId isEqualToString:fieldUuid]) {
-                        // We found this field. Continue to next sortField.
-                        continue;
+                        foundThisField = YES;
+                        break;
                     }
                 }
                 
-                // We have a contact field UUID but could not find any field with that UUID in this service.
-                SBLogInfo(@"Field %@ does not exist in the current service, so it can no longer be used for sorting.", fieldUuid);
-                return NO;
+                if (!foundThisField) {
+                    SBLogInfo(@"Field %@ does not exist in the current service, so it can no longer be used for sorting.", fieldUuid);
+                    return NO;
+                }
             }
         }
     }

--- a/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.m
+++ b/Pod/Classes/UI/ViewModels/Contacts/ZNGContactDataSetBuilder.m
@@ -12,6 +12,8 @@
 #import "ZNGLabel.h"
 #import "ZNGContactGroup.h"
 
+@import SBObjectiveCWrapper;
+
 @implementation ZNGContactDataSetBuilder
 
 - (ZNGInboxDataSet *)build
@@ -119,6 +121,34 @@
         
         if (matchingGroupIndex == NSNotFound) {
             return NO;
+        }
+    }
+    
+    // Use a regex just strict enough to identify contact field UUIDs vs. named fields like `last_message_at`
+    NSString * uuidPattern = @"^([-0-9a-f]{8,64})(\\s+(asc)|(desc)\\.?)$";
+    NSRegularExpression * uuidRegex = [[NSRegularExpression alloc] initWithPattern:uuidPattern options:NSRegularExpressionCaseInsensitive error:nil];
+    
+    // Check each sort field to ensure that every field referenced by UUID exists in this session
+    for (NSString * sortField in self.sortFields) {
+        NSTextCheckingResult * result = [uuidRegex firstMatchInString:sortField options:0 range:NSMakeRange(0, [sortField length])];
+        
+        if (result != nil) {
+            NSRange uuidRange = [result rangeAtIndex:1];  // Capture group 1 is the UUID itself without asc/desc
+            
+            if (uuidRange.location != NSNotFound) {
+                NSString * fieldUuid = [sortField substringWithRange:uuidRange];
+                
+                for (ZNGContactField * field in session.service.contactCustomFields) {
+                    if ([field.contactFieldId isEqualToString:fieldUuid]) {
+                        // We found this field. Continue to next sortField.
+                        continue;
+                    }
+                }
+                
+                // We have a contact field UUID but could not find any field with that UUID in this service.
+                SBLogInfo(@"Field %@ does not exist in the current service, so it can no longer be used for sorting.", fieldUuid);
+                return NO;
+            }
         }
     }
     


### PR DESCRIPTION
https://jira.medallia.com/browse/ZIN-1648

Added a check to the existing `canBeUsedForSession:` on inbox data to check if contact fields used in sorting are available in the current session.

![guy](https://user-images.githubusercontent.com/1328743/101087625-52ae7280-3567-11eb-9f65-e6e6c48f2feb.gif)
