### PR TITLE
Added a public method that is called when performing animated inbox table row deletion

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGInboxViewController.h
+++ b/Pod/Classes/UI/Controllers/ZNGInboxViewController.h
@@ -45,6 +45,11 @@
 
 - (void)refresh:(nullable UIRefreshControl *)refreshControl;
 
+// Internal method used to delete rows. Can be overriden by subclasses with more table data to manage.
+// This is some pain that comes from having a split implementation, with the subclass managing empty states
+//  via new table sections.
+- (void) deleteRowsAtPaths:(NSArray <NSIndexPath *> * _Nonnull)paths withAnimation:(UITableViewRowAnimation)animation;
+
 /**
  *  The data set that will be used if the view appears without any current data.  Defaults to a new ZNGInboxDataSet.
  */

--- a/Pod/Classes/UI/Controllers/ZNGInboxViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGInboxViewController.m
@@ -372,7 +372,7 @@ static NSString * const AssignmentSwipeActionUIType = @"inbox swipe action";
             SBLogVerbose(@"Removing %ld items", (unsigned long)[paths count]);
             
             if (([paths count] == 1) && (!pendingReloadBlockedBySwipe)) {
-                [self.tableView deleteRowsAtIndexPaths:paths withRowAnimation:UITableViewRowAnimationTop];
+                [self deleteRowsAtPaths:paths withAnimation:UITableViewRowAnimationTop];
                 [self retainSelection];
             } else {
                 [self reloadTableData];
@@ -394,6 +394,11 @@ static NSString * const AssignmentSwipeActionUIType = @"inbox swipe action";
             // For either an unknown change or a whole array replacement (which we do not expect with non-empty data,) blow away the table and reload it
             [self reloadTableData];
     }
+}
+
+- (void) deleteRowsAtPaths:(NSArray <NSIndexPath *> * _Nonnull)paths withAnimation:(UITableViewRowAnimation)animation
+{
+    [self.tableView deleteRowsAtIndexPaths:paths withRowAnimation:UITableViewRowAnimationTop];
 }
 
 /**


### PR DESCRIPTION
If subclasses of `ZNGInboxViewController` add their own data to the table, they may need to manage it explicitly when `ZNGInboxViewController` is deleting rows via `deleteRows:`. Subclasses can override this new method to do so.

![continue](https://user-images.githubusercontent.com/1328743/101324321-e6f62f00-381e-11eb-8119-415f838cc528.gif)
