### PR TITLE
ZIN-2095: Fix setting date to nil causing a crash on older versions iOS

### DIFF
--- a/Pod/Classes/UI/Views/Contact Editing/ZNGContactDateOrTimeFieldTableViewCell.m
+++ b/Pod/Classes/UI/Views/Contact Editing/ZNGContactDateOrTimeFieldTableViewCell.m
@@ -79,7 +79,7 @@
     [super updateDisplay];
     
     self.textField.text = [inputManager displayValue];
-    datePicker.date = [inputManager valueAsDate];
+    datePicker.date = [inputManager valueAsDate] ?: [NSDate date];
     
     [self repairStupidBrokenDatePicker:datePicker];
 }


### PR DESCRIPTION
https://jira.medallia.com/browse/ZIN-2095
https://console.firebase.google.com/u/1/project/medallia-zingle/crashlytics/app/ios:com.zingleme.Zingle/issues/7035cc8e8e22f267e47b7a5ff4fe4bda

This was seen on a customer device running iOS 12.4.9 and was reproduced in a 12.4 simulator.