### PR TITLE
ZIN-2247: Fix regression that sometimes erases text contact fields

### DIFF
--- a/Pod/Classes/UI/Views/Contact Editing/ZNGContactTextFieldTableViewCell.m
+++ b/Pod/Classes/UI/Views/Contact Editing/ZNGContactTextFieldTableViewCell.m
@@ -25,6 +25,7 @@
 {
     [super configureInput];
     
+    self.textField.text = self.customFieldValue.value;
     self.textField.placeholder = self.customFieldValue.customField.displayName;
     self.textField.enabled = !self.editingLocked;
     self.textField.clearButtonMode = UITextFieldViewModeAlways;


### PR DESCRIPTION
https://jira.medallia.com/browse/ZIN-2247

It looks like text fields have been broken since https://github.com/Zingle/ios-sdk/pull/284

![party](https://i.imgur.com/T1Ouqy0.gif)