### PR TITLE
ZIN-2445: Add channel ID to outbound messages

### DIFF
--- a/Example/Tests/TestConversation.m
+++ b/Example/Tests/TestConversation.m
@@ -16,6 +16,8 @@
 #import "ZNGMockServiceClient.h"
 #import "ZNGMockEventClient.h"
 
+static NSString * const channelId = @"AAAA-22222222222-333333333333-DDDD";
+
 @interface TestConversation : XCTestCase
 
 @end
@@ -31,6 +33,7 @@
     ZNGChannelType * channelType = [[ZNGChannelType alloc] init];
     channelType.channelTypeId = @"1111-22222222222-333333333333-4444";
     channel.channelType = channelType;
+    channel.channelId = channelId;
     
     ZNGMockMessageClient * messageClient = [[ZNGMockMessageClient alloc] init];
     
@@ -173,6 +176,12 @@
             NSLog(@"Actual value of events array is: %@", conversation.events);
         }
     }];
+}
+
+- (void) testOutboundMessagesSendByChannelUuid
+{
+    ZNGConversationServiceToContact * conversation = [self freshConversation];
+    XCTAssertEqualObjects([conversation receiver].channelId, channelId, @"Service-to-contact conversation sends channel UUID in outbound messages.");
 }
 
 @end

--- a/Pod/Classes/Models/ZNGParticipant.h
+++ b/Pod/Classes/Models/ZNGParticipant.h
@@ -23,6 +23,7 @@ typedef NS_ENUM(NSInteger, ZNGParticipantType) {
 @property(nonatomic, strong, nonnull) NSString* participantId;
 @property(nonatomic, strong, nullable) NSString* channelType;
 @property(nonatomic, strong, nullable) NSString* channelValue;
+@property(nonatomic, strong, nullable) NSString* channelId;
 @property(nonatomic, strong, nullable) NSString* name;
 
 + (ZNGParticipant *)participantForServiceId:(NSString *)serviceId withServiceChannelValue:(NSString *)serviceChannelValue;

--- a/Pod/Classes/Models/ZNGParticipant.m
+++ b/Pod/Classes/Models/ZNGParticipant.m
@@ -12,7 +12,11 @@
 
 + (NSDictionary*)JSONKeyPathsByPropertyKey
 {
-    return @{ @"participantId" : @"id", @"channelValue" : @"channel_value" };
+    return @{
+        @"participantId" : @"id",
+        @"channelValue" : @"channel_value",
+        @"channelId" : @"channel_id",
+    };
 }
 
 + (ZNGParticipant *)participantForServiceId:(NSString *)serviceId withServiceChannelValue:(NSString *)serviceChannelValue

--- a/Pod/Classes/UI/ViewModels/Events/ZNGConversationServiceToContact.m
+++ b/Pod/Classes/UI/ViewModels/Events/ZNGConversationServiceToContact.m
@@ -249,6 +249,7 @@ static NSString * const ChannelsKVOPath = @"contact.channels";
 {
     ZNGParticipant * participant = [[ZNGParticipant alloc] init];
     participant.channelValue = self.channel.value;
+    participant.channelId = self.channel.channelId;
     return participant;
 }
 


### PR DESCRIPTION
https://jira.medallia.com/browse/ZIN-2445

Previously we sent just channel value. The API just started obfuscating channel values when contact privacy is enabled. This was breaking outbound messages. Adding the ID fixes it.

![U45MS-Label-Dispenser](https://user-images.githubusercontent.com/1328743/110176501-3dd8b980-7db8-11eb-82a2-3543d1e316c5.gif)
