### PR TITLE
ZIN-2501: Fix regression saving contact field edits when "save" is hit with input still active in a text field

### DIFF
--- a/Pod/Classes/UI/Controllers/ZNGContactEditViewController.m
+++ b/Pod/Classes/UI/Controllers/ZNGContactEditViewController.m
@@ -422,7 +422,7 @@ static NSString * const EventCellId = @"event";
 - (void) saveAnyEditsInProgress
 {
     for (ZNGContactCustomFieldTableViewCell * cell in [self.tableView visibleCells]) {
-        if ([cell isKindOfClass:[ZNGContactCustomFieldTableViewCell class]]) {
+        if ([cell isKindOfClass:[ZNGContactEditTableViewCell class]]) {
             [cell applyInProgressChanges];
         }
     }

--- a/Pod/Classes/UI/Views/Contact Editing/ZNGContactChannelTableViewCell.m
+++ b/Pod/Classes/UI/Views/Contact Editing/ZNGContactChannelTableViewCell.m
@@ -40,7 +40,7 @@
     [self updateUI];
 }
 
-- (void) applyChangesIfFirstResponder
+- (void) applyInProgressChanges
 {
     if ([self.textField isFirstResponder]) {
         [self.channel setValueFromTextEntry:self.textField.text];

--- a/Pod/Classes/UI/Views/Contact Editing/ZNGContactCustomFieldTableViewCell.h
+++ b/Pod/Classes/UI/Views/Contact Editing/ZNGContactCustomFieldTableViewCell.h
@@ -17,11 +17,6 @@
 @property (nonatomic, strong, nullable) ZNGContactFieldValue * customFieldValue;
 
 /**
- *  Instructs the cell to write any in-progress (read: input is first responder) changes.
- */
-- (void) applyInProgressChanges;
-
-/**
  *  Called whenever the custom field value object is set (NOT when the text `.value` is changed)
  */
 - (void) configureInput;

--- a/Pod/Classes/UI/Views/Contact Editing/ZNGContactDefaultFieldsTableViewCell.m
+++ b/Pod/Classes/UI/Views/Contact Editing/ZNGContactDefaultFieldsTableViewCell.m
@@ -149,7 +149,7 @@
 }
 
 #pragma mark -
-- (void) applyChangesIfFirstResponder
+- (void) applyInProgressChanges
 {
     if (self.firstNameField.isFirstResponder) {
         self.firstNameFieldValue.value = self.firstNameField.text;

--- a/Pod/Classes/UI/Views/Contact Editing/ZNGContactEditTableViewCell.h
+++ b/Pod/Classes/UI/Views/Contact Editing/ZNGContactEditTableViewCell.h
@@ -13,7 +13,7 @@
 /**
  *  Abstract method that should be implemented by subclasses
  */
-- (void) applyChangesIfFirstResponder;
+- (void) applyInProgressChanges;
 
 @property (nonatomic) BOOL editingLocked;
 

--- a/Pod/Classes/UI/Views/Contact Editing/ZNGContactEditTableViewCell.m
+++ b/Pod/Classes/UI/Views/Contact Editing/ZNGContactEditTableViewCell.m
@@ -10,7 +10,7 @@
 
 @implementation ZNGContactEditTableViewCell
 
-- (void) applyChangesIfFirstResponder
+- (void) applyInProgressChanges
 {
     // Abstract implementation
 }

--- a/Pod/Classes/UI/Views/Contact Editing/ZNGContactPhoneNumberTableViewCell.m
+++ b/Pod/Classes/UI/Views/Contact Editing/ZNGContactPhoneNumberTableViewCell.m
@@ -63,7 +63,7 @@
     self.textField.text = value;
 }
 
-- (void) applyChangesIfFirstResponder
+- (void) applyInProgressChanges
 {
     if ([self.textField isFirstResponder]) {
         [self.channel setValueFromTextEntry:self.textField.text];

--- a/Pod/Classes/UI/Views/Contact Editing/ZNGContactSingleSelectFieldTableViewCell.m
+++ b/Pod/Classes/UI/Views/Contact Editing/ZNGContactSingleSelectFieldTableViewCell.m
@@ -62,7 +62,9 @@
 {
     // We only need to handle bools. Other cases set values automatically when UIPickerView values change.
     if ([self.customFieldValue.customField.dataType isEqualToString:ZNGContactFieldDataTypeBool]) {
-        self.customFieldValue.value = ([self.customFieldValue.value boolValue]) ? @"true" : @"false";
+        if ([self.customFieldValue.value length] > 0) {
+            self.customFieldValue.value = ([self.customFieldValue.value boolValue]) ? @"true" : @"false";
+        }
     }
 }
 


### PR DESCRIPTION
https://jira.medallia.com/browse/ZIN-2501

There was an awkward mix of the old `applyChangesIfFirstResponder` logic and the newer `applyInProgressChanges` logic. There can be only one.

Also fixed a further regression that this caused which would save `false` for bool fields that had not actually been edited.

![200](https://user-images.githubusercontent.com/1328743/110697543-59b9d200-81a1-11eb-9e79-617468568013.gif)
