### PR TITLE
Removed code that guessed at JWT full expiration time

### DIFF
--- a/Pod/Classes/Clients/ZNGJWTClient.m
+++ b/Pod/Classes/Clients/ZNGJWTClient.m
@@ -114,26 +114,6 @@
         return;
     }
     
-    NSDate * refreshExpiration = [jwt jwtRefreshExpiration];
-    
-    if (refreshExpiration == nil) {
-        SBLogWarning(@"Unable to determine refrehs window for the refreshing JWT.  This may fail.");
-    } else {
-        if ([refreshExpiration timeIntervalSinceNow] <= 0.0) {
-            NSString * description = [NSString stringWithFormat:@"Unable to refresh JWT.  Its refresh window closed at %@", refreshExpiration];
-            SBLogWarning(@"%@", description);
-            
-            if (failure != nil) {
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    NSError * error = [NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey: description}];
-                    failure(error);
-                });
-            }
-            
-            return;
-        }
-    }
-    
     AFHTTPSessionManager * authedSession = [session copy];
     [authedSession.requestSerializer setValue:[NSString stringWithFormat:@"Bearer %@", jwt] forHTTPHeaderField:@"Authorization"];
     

--- a/Pod/Classes/Utility/NSString+ZNGJWT.h
+++ b/Pod/Classes/Utility/NSString+ZNGJWT.h
@@ -15,12 +15,6 @@
 - (NSDate * _Nullable) jwtExpiration;
 
 /**
- *  The final moment this JWT can be refreshed.  Simply returns 14 days past the issue date at the moment.
- *  Returns nil if the string is not a JWT or has no issued timestamp (iat).
- */
-- (NSDate * _Nullable) jwtRefreshExpiration;
-
-/**
  *  The issue date for this JWT.  Nil if not a JWT.
  */
 - (NSDate * _Nullable) jwtIssueDate;

--- a/Pod/Classes/Utility/NSString+ZNGJWT.m
+++ b/Pod/Classes/Utility/NSString+ZNGJWT.m
@@ -66,18 +66,6 @@ static NSString * const JwtPayloadKeyHipaaUser = @"hipaa";
     return [NSDate dateWithTimeIntervalSince1970:[iatNumber doubleValue]];
 }
 
-- (NSDate * _Nullable) jwtRefreshExpiration
-{
-    NSDate * issueDate = [self jwtIssueDate];
-    
-    if (issueDate == nil) {
-        return nil;
-    }
-    
-    NSTimeInterval fourteenDays = 14.0 * 24.0 * 60.0 * 60.0;
-    return [NSDate dateWithTimeInterval:fourteenDays sinceDate:issueDate];
-}
-
 - (NSURL * _Nullable) jwtIssuingUrl
 {
     return [NSURL URLWithString:[self jwtPayload][JwtPayloadKeyIssuingUrl]];


### PR DESCRIPTION
This was a guess, at best, was causing issues with HIPAA biometric login, and now opaquely varies for standard vs. HIPAA users.

The newer JWT refreshing code now gracefully handles these errors and will work around them if possible (e.g. saved credentials exist) anyway.

![stop-guessing-content-marketing](https://user-images.githubusercontent.com/1328743/119195783-0635f100-ba3a-11eb-8b46-04ce661a6c4c.jpg)
